### PR TITLE
Use terraform actions from cnp-githubactions-library

### DIFF
--- a/.github/workflows/job.terraform-fmt.yml
+++ b/.github/workflows/job.terraform-fmt.yml
@@ -1,7 +1,7 @@
 # Terraform Format Check Job
 #
 # Checks that all Terraform files are properly formatted.
-# Call this job only when infrastructure changes are detected.
+# This is a thin wrapper around the cnp-githubactions-library terraform-fmt action.
 #
 # Usage:
 #   terraform-fmt:
@@ -28,15 +28,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version_file: ${{ inputs.working-directory }}/.terraform-version
-
       - name: Terraform Format Check
-        working-directory: ${{ inputs.working-directory }}
-        run: |
-          if ! terraform fmt -check -recursive -diff; then
-            echo "::error::Terraform files are not formatted. Run 'terraform fmt -recursive' in the infrastructure directory to fix."
-            exit 1
-          fi
+        uses: hmcts/cnp-githubactions-library/terraform-fmt@main
+        with:
+          working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/job.terraform.yml
+++ b/.github/workflows/job.terraform.yml
@@ -1,7 +1,7 @@
 # Terraform Job
 #
 # Runs Terraform plan and optionally apply for infrastructure changes.
-# Call this job only when infrastructure changes are detected.
+# This is a thin wrapper around the cnp-githubactions-library terraform-deploy workflow.
 #
 # Usage:
 #   terraform:
@@ -11,6 +11,7 @@
 #     with:
 #       environment: aat
 #       subscription: DCD-CNP-DEV
+#       aks-subscription: DCD-CFTAPPS-STG
 #       storage-account: nonprod
 #       plan-only: true
 #     secrets: inherit
@@ -35,7 +36,7 @@ on:
       aks-subscription:
         required: true
         type: string
-        description: "Azure subscription name for AKS cluster (contains network subnets, e.g. DCD-CFTAPPS-STG)"
+        description: "Azure subscription name for AKS cluster (e.g. DCD-CFTAPPS-STG)"
       plan-only:
         required: false
         type: boolean
@@ -53,213 +54,14 @@ on:
 jobs:
   terraform:
     name: Terraform ${{ inputs.plan-only && 'Plan' || 'Apply' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    outputs:
-      plan-exitcode: ${{ steps.plan.outputs.exitcode }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Extract team name from Chart.yaml
-        id: metadata
-        run: |
-          CHART_FILE="helm/expressjs-monorepo-template/Chart.yaml"
-          # Extract team from annotations (same pattern as helm-deploy)
-          TEAM=$(grep -A 1 'annotations:' "$CHART_FILE" | grep 'team:' | awk '{print $2}' | tr -d '"')
-          if [ -z "$TEAM" ]; then
-            echo "::error::No team annotation found in $CHART_FILE"
-            exit 1
-          fi
-          echo "product=$TEAM" >> "$GITHUB_OUTPUT"
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version_file: ${{ inputs.working-directory }}/.terraform-version
-          terraform_wrapper: false  # Disable wrapper to preserve exit codes
-
-      - name: Azure Login
-        uses: azure/login@v2
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS_CFT_PREVIEW }}
-
-      - name: Get Azure context
-        id: azure-context
-        run: |
-          # Extract tenant ID and service principal object ID from logged-in context
-          TENANT_ID=$(az account show --query tenantId -o tsv)
-          CLIENT_ID=$(az account show --query user.name -o tsv)
-          SP_OBJECT_ID=$(az ad sp show --id "$CLIENT_ID" --query id -o tsv)
-
-          echo "tenant_id=$TENANT_ID" >> "$GITHUB_OUTPUT"
-          echo "sp_object_id=$SP_OBJECT_ID" >> "$GITHUB_OUTPUT"
-
-      - name: Set subscription
-        id: subscription
-        run: |
-          az account set --subscription "${{ inputs.subscription }}"
-          SUBSCRIPTION_ID=$(az account show --query id -o tsv)
-          echo "id=$SUBSCRIPTION_ID" >> "$GITHUB_OUTPUT"
-
-      - name: Resolve AKS subscription ID
-        id: aks-subscription
-        run: |
-          AKS_SUBSCRIPTION_ID=$(az account show --subscription "${{ inputs.aks-subscription }}" --query id -o tsv)
-          echo "id=$AKS_SUBSCRIPTION_ID" >> "$GITHUB_OUTPUT"
-
-      - name: Get Storage Account Key
-        id: storage-key
-        run: |
-          STORAGE_ACCOUNT="mgmtstatestore${{ inputs.storage-account }}"
-          RESOURCE_GROUP="mgmt-state-store-${{ inputs.storage-account }}"
-          KEY=$(az storage account keys list \
-            --account-name "$STORAGE_ACCOUNT" \
-            --resource-group "$RESOURCE_GROUP" \
-            --query '[0].value' -o tsv)
-          echo "::add-mask::$KEY"
-          echo "key=$KEY" >> "$GITHUB_OUTPUT"
-
-      # TODO: Use terraform actions rather than DIY
-
-      - name: Terraform Init
-        working-directory: ${{ inputs.working-directory }}
-        env:
-          ARM_ACCESS_KEY: ${{ steps.storage-key.outputs.key }}
-        run: |
-          terraform init -reconfigure \
-            -backend-config="storage_account_name=mgmtstatestore${{ inputs.storage-account }}" \
-            -backend-config="container_name=mgmtstatestorecontainer${{ inputs.environment }}" \
-            -backend-config="resource_group_name=mgmt-state-store-${{ inputs.storage-account }}" \
-            -backend-config="key=${{ github.event.repository.name }}/${{ inputs.environment }}/terraform.tfstate"
-
-      - name: Terraform Validate
-        working-directory: ${{ inputs.working-directory }}
-        run: terraform validate
-
-      - name: Terraform Plan
-        id: plan
-        working-directory: ${{ inputs.working-directory }}
-        env:
-          ARM_ACCESS_KEY: ${{ steps.storage-key.outputs.key }}
-          PRODUCT: ${{ steps.metadata.outputs.product }}
-          TENANT_ID: ${{ steps.azure-context.outputs.tenant_id }}
-          SP_OBJECT_ID: ${{ steps.azure-context.outputs.sp_object_id }}
-        run: |
-          # Map environment names to Azure policy-compliant values
-          # See: https://github.com/hmcts/azure-policy/blob/master/policies/tagging/README.md
-          case "${{ inputs.environment }}" in
-            prod|production) ENV_TAG="production" ;;
-            aat|stg|staging) ENV_TAG="staging" ;;
-            dev|development) ENV_TAG="development" ;;
-            test|testing) ENV_TAG="testing" ;;
-            demo) ENV_TAG="demo" ;;
-            ithc) ENV_TAG="ithc" ;;
-            sbox|sandbox) ENV_TAG="sandbox" ;;
-            *) ENV_TAG="${{ inputs.environment }}" ;;
-          esac
-
-          # Construct common_tags as compact JSON and write to tfvars file
-          # This avoids shell quoting issues with the -var flag
-          jq -c -n \
-            --arg env "$ENV_TAG" \
-            --arg managedBy "$PRODUCT" \
-            --arg builtFrom "$GITHUB_REPOSITORY" \
-            --arg application "$PRODUCT" \
-            --arg businessArea "CFT" \
-            '{environment: $env, managedBy: $managedBy, builtFrom: $builtFrom, application: $application, businessArea: $businessArea}' \
-            > common_tags.json
-
-          echo "common_tags = $(cat common_tags.json)" > terraform.auto.tfvars
-
-          set +e
-          terraform plan -detailed-exitcode -out=tfplan \
-            -var "env=${{ inputs.environment }}" \
-            -var "product=${PRODUCT}" \
-            -var "subscription=${{ steps.subscription.outputs.id }}" \
-            -var "aks_subscription_id=${{ steps.aks-subscription.outputs.id }}" \
-            -var "tenant_id=${TENANT_ID}" \
-            -var "builtFrom=${GITHUB_REPOSITORY}" \
-            -var "ci_service_principal_object_id=${SP_OBJECT_ID}"
-          EXITCODE=$?
-          echo "exitcode=$EXITCODE" >> "$GITHUB_OUTPUT"
-          if [ $EXITCODE -eq 1 ]; then
-            exit 1
-          fi
-
-      - name: Save Plan Output
-        if: ${{ github.event.pull_request.number && steps.plan.outputs.exitcode == '2' }}
-        working-directory: ${{ inputs.working-directory }}
-        run: terraform show -no-color tfplan > plan.txt
-
-      - name: Post Plan to PR
-        if: ${{ github.event.pull_request.number && steps.plan.outputs.exitcode == '2' }}
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const fs = require('fs');
-            const path = require('path');
-            const planPath = path.join('${{ inputs.working-directory }}', 'plan.txt');
-            const plan = fs.readFileSync(planPath, 'utf8');
-
-            const maxLength = 60000;
-            const truncatedPlan = plan.length > maxLength
-              ? plan.substring(0, maxLength) + '\n\n... (truncated)'
-              : plan;
-
-            const body = [
-              '### Terraform Plan for `${{ inputs.environment }}`',
-              '',
-              '<details>',
-              '<summary>Show Plan</summary>',
-              '',
-              '```terraform',
-              truncatedPlan,
-              '```',
-              '',
-              '</details>'
-            ].join('\n');
-
-            const prNumber = context.payload.pull_request?.number;
-            if (!prNumber) {
-              console.log('No PR number found, skipping comment');
-              return;
-            }
-
-            const { data: comments } = await github.rest.issues.listComments({
-              issue_number: prNumber,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-            });
-
-            const botComment = comments.find(comment =>
-              comment.user.type === 'Bot' &&
-              comment.body.includes('Terraform Plan for `${{ inputs.environment }}`')
-            );
-
-            if (botComment) {
-              await github.rest.issues.updateComment({
-                comment_id: botComment.id,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: body
-              });
-            } else {
-              await github.rest.issues.createComment({
-                issue_number: prNumber,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: body
-              });
-            }
-
-      - name: Terraform Apply
-        if: ${{ !inputs.plan-only && steps.plan.outputs.exitcode == '2' }}
-        working-directory: ${{ inputs.working-directory }}
-        run: terraform apply -auto-approve tfplan
-        env:
-          ARM_ACCESS_KEY: ${{ steps.storage-key.outputs.key }}
-
+    uses: hmcts/cnp-githubactions-library/.github/workflows/terraform-deploy.yaml@main
+    with:
+      environment: ${{ inputs.environment }}
+      subscription: ${{ inputs.subscription }}
+      aks-subscription: ${{ inputs.aks-subscription }}
+      storage-account: ${{ inputs.storage-account }}
+      working-directory: ${{ inputs.working-directory }}
+      plan-only: ${{ inputs.plan-only }}
+      helm-chart-path: helm/expressjs-monorepo-template/Chart.yaml
+    secrets:
+      AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS_CFT_PREVIEW }}


### PR DESCRIPTION
## Summary

- Replace DIY terraform implementation with reusable actions from [cnp-githubactions-library](https://github.com/hmcts/cnp-githubactions-library)
- `job.terraform.yml` now delegates to the `terraform-deploy.yaml` reusable workflow
- `job.terraform-fmt.yml` now uses the `terraform-fmt` composite action

## Changes

| File | Change |
|------|--------|
| `job.terraform.yml` | ~220 lines of DIY terraform steps → 15 lines calling library workflow |
| `job.terraform-fmt.yml` | DIY setup/format steps → library composite action |

## Test plan

- [ ] Verify terraform format check works on PR
- [ ] Verify terraform plan output appears in PR comment
- [ ] Verify terraform apply works on merge to master

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined Terraform formatting check to use a centralised GitHub Actions step.
  * Refactored Terraform deployment job to delegate to a reusable external workflow for consistency and reduced duplication.
  * Added a helm-chart-path input to the Terraform workflow to support chart-aware deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->