### PR TITLE
Fix @spec action to post comments to GitHub issues

### DIFF
--- a/.github/workflows/workflow.claude.yml
+++ b/.github/workflows/workflow.claude.yml
@@ -118,6 +118,13 @@ jobs:
       issues: write
       id-token: write
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CLAUDE_CODE_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_CODE_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
@@ -164,7 +171,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.CLAUDE_API_KEY }}
-          github_token: ${{ github.token }}
+          github_token: ${{ steps.app-token.outputs.token }}
           prompt: |
             Generate a technical specification for this GitHub issue using the specified template.
 


### PR DESCRIPTION
## Summary
- Add GitHub App token generation to the `spec` job for proper authentication
- Add `github_token` parameter to allow Claude to post comments
- Update `--allowedTools` to include `Bash(gh issue comment:*)` 
- Update prompt to instruct Claude to post the spec directly to the issue

## Problem
The `@spec` command ran successfully but never posted the generated specification as a comment. The prompt misleadingly said "Your entire output will be posted as a GitHub issue comment" but there was no mechanism to actually do this.

## Test plan
- [ ] Create a test issue in the repository
- [ ] Comment `@spec` on the issue
- [ ] Verify the GitHub Action runs successfully
- [ ] Verify a comment is posted with the generated specification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated GitHub workflow automation to post specification generation results directly as GitHub issue comments.
  * Enhanced workflow security and token handling for improved GitHub API interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->