### PR TITLE
chore: migrate ACR from hmctspublic to hmctsprod

### DIFF
--- a/.claude/agents/infrastructure-engineer.md
+++ b/.claude/agents/infrastructure-engineer.md
@@ -202,7 +202,7 @@ dependencies:
   # Preview environment dependencies
   - name: postgresql
     version: 1.1.0
-    repository: oci://hmctspublic.azurecr.io/helm
+    repository: oci://hmctsprod.azurecr.io/helm
     condition: postgresql.enabled
   - name: redis
     version: 24.1.2
@@ -218,13 +218,13 @@ App subcharts depend on HMCTS base charts from the OCI registry:
 dependencies:
   - name: nodejs
     version: 3.2.0
-    repository: 'oci://hmctspublic.azurecr.io/helm'
+    repository: 'oci://hmctsprod.azurecr.io/helm'
 
 # apps/crons/helm/Chart.yaml - Cron jobs and migrations
 dependencies:
   - name: job
     version: 2.2.0
-    repository: 'oci://hmctspublic.azurecr.io/helm'
+    repository: 'oci://hmctsprod.azurecr.io/helm'
 ```
 
 ### Subchart Values Configuration
@@ -235,7 +235,7 @@ nodejs:
   applicationPort: 3000
   aadIdentityName: dtsse
   ingressHost: expressjs-monorepo-template-web.{{ .Values.global.environment }}.platform.hmcts.net
-  image: 'hmctspublic.azurecr.io/dtsse/expressjs-monorepo-template-web:latest'
+  image: 'hmctsprod.azurecr.io/dtsse/expressjs-monorepo-template-web:latest'
   environment:
     REDIS_URL: 'redis://dtsse-{{ .Values.global.environment }}.redis.cache.windows.net:6379'
   keyVaults:
@@ -263,7 +263,7 @@ api:
 
 expressjs-monorepo-template-web:
   nodejs:
-    image: "hmctspublic.azurecr.io/dtsse/expressjs-monorepo-template-web:${WEB_IMAGE}"
+    image: "hmctsprod.azurecr.io/dtsse/expressjs-monorepo-template-web:${WEB_IMAGE}"
     ingressHost: "${TEAM_NAME}-expressjs-monorepo-template-web.${ENVIRONMENT}.platform.hmcts.net"
     secrets:
       POSTGRES_HOST:
@@ -284,7 +284,7 @@ global:
 
 expressjs-monorepo-template-web:
   nodejs:
-    image: "hmctspublic.azurecr.io/dtsse/expressjs-monorepo-template-web:${WEB_IMAGE}"
+    image: "hmctsprod.azurecr.io/dtsse/expressjs-monorepo-template-web:${WEB_IMAGE}"
     ingressHost: "${TEAM_NAME}-{{ .Release.Name }}-web.preview.platform.hmcts.net"
     environment:
       REDIS_URL: "redis://{{ .Release.Name }}-redis-master:6379"
@@ -371,7 +371,7 @@ Deployments use `hmcts/cnp-githubactions-library/helm-deploy`:
     chart: helm/${{ env.APPLICATION_NAME }}
     values-template: helm/${{ env.APPLICATION_NAME }}/values.template.yaml
     subchart-paths: apps/*/helm
-    oci-registry: hmctspublic.azurecr.io
+    oci-registry: hmctsprod.azurecr.io
 ```
 
 ## Pod Diagnostics and Troubleshooting
@@ -475,7 +475,7 @@ terraform output
 az login
 az account set --subscription "DCD-CNP-DEV"
 az aks get-credentials --resource-group <rg> --name <cluster>
-az acr login --name hmctspublic
+az acr login --name hmctsprod
 az keyvault secret list --vault-name <vault>
 az keyvault secret show --vault-name <vault> --name <secret>
 

--- a/.github/workflows/job.build-and-publish-images.yml
+++ b/.github/workflows/job.build-and-publish-images.yml
@@ -26,7 +26,7 @@ on:
 
 env:
   CHANGE_ID: ${{ inputs.change-id }}
-  REGISTRY_NAME: hmctspublic
+  REGISTRY_NAME: hmctsprod
 
 jobs:
   get-last-successful-sha:

--- a/.github/workflows/job.helm-deploy.yml
+++ b/.github/workflows/job.helm-deploy.yml
@@ -41,7 +41,7 @@ on:
 
 env:
   CHANGE_ID: ${{ inputs.change-id }}
-  REGISTRY: hmctspublic.azurecr.io
+  REGISTRY: hmctsprod.azurecr.io
 
 jobs:
   helm-deploy:

--- a/.github/workflows/job.helm-deploy.yml
+++ b/.github/workflows/job.helm-deploy.yml
@@ -48,8 +48,6 @@ jobs:
   helm-deploy:
     name: Deploy to ${{ inputs.environment }}
     runs-on: ubuntu-latest
-    environment:
-      name: ${{ inputs.environment }}
     outputs:
       urls: ${{ steps.urls.outputs.urls }}
       release-name: ${{ env.RELEASE_NAME }}

--- a/.github/workflows/job.helm-deploy.yml
+++ b/.github/workflows/job.helm-deploy.yml
@@ -42,7 +42,6 @@ on:
 env:
   CHANGE_ID: ${{ inputs.change-id }}
   REGISTRY: hmctsprod.azurecr.io
-  REGISTRY_NAME: hmctsprod
 
 jobs:
   helm-deploy:
@@ -91,7 +90,7 @@ jobs:
           allow-no-subscriptions: true
 
       - name: ACR login
-        run: az acr login --name ${{ env.REGISTRY_NAME }}
+        run: az acr login --name "${REGISTRY%.azurecr.io}"
 
       - name: Deploy to preview
         if: inputs.environment == 'preview'

--- a/.github/workflows/job.helm-deploy.yml
+++ b/.github/workflows/job.helm-deploy.yml
@@ -42,6 +42,7 @@ on:
 env:
   CHANGE_ID: ${{ inputs.change-id }}
   REGISTRY: hmctsprod.azurecr.io
+  REGISTRY_NAME: hmctsprod
 
 jobs:
   helm-deploy:
@@ -84,6 +85,16 @@ jobs:
             '${{ inputs.timestamp }}' \
             "${APPLICATION_NAME}"
 
+      - name: Azure login for ACR (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      - name: ACR login
+        run: az acr login --name ${{ env.REGISTRY_NAME }}
+
       - name: Deploy to preview
         if: inputs.environment == 'preview'
         id: deploy-preview
@@ -98,9 +109,6 @@ jobs:
           chart: helm/${{ env.APPLICATION_NAME }}
           values-template: helm/${{ env.APPLICATION_NAME }}/values.preview.template.yaml
           subchart-paths: apps/*/helm
-          oci-registry: ${{ env.REGISTRY }}
-          oci-username: ${{ secrets.REGISTRY_USERNAME }}
-          oci-password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: Deploy to AAT
         if: inputs.environment == 'aat'
@@ -116,9 +124,6 @@ jobs:
           chart: helm/${{ env.APPLICATION_NAME }}
           values-template: helm/${{ env.APPLICATION_NAME }}/values.template.yaml
           subchart-paths: apps/*/helm
-          oci-registry: ${{ env.REGISTRY }}
-          oci-username: ${{ secrets.REGISTRY_USERNAME }}
-          oci-password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: Register DNS for AAT
         if: inputs.environment == 'aat'

--- a/.github/workflows/job.helm-publish.yml
+++ b/.github/workflows/job.helm-publish.yml
@@ -10,7 +10,6 @@ on:
 
 env:
   REGISTRY: hmctsprod.azurecr.io
-  REGISTRY_NAME: hmctsprod
 
 jobs:
   publish:
@@ -37,7 +36,7 @@ jobs:
           allow-no-subscriptions: true
 
       - name: ACR login
-        run: az acr login --name ${{ env.REGISTRY_NAME }}
+        run: az acr login --name "${REGISTRY%.azurecr.io}"
 
       - name: Add Bitnami repo
         run: helm repo add bitnami https://charts.bitnami.com/bitnami

--- a/.github/workflows/job.helm-publish.yml
+++ b/.github/workflows/job.helm-publish.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   REGISTRY: hmctsprod.azurecr.io
+  REGISTRY_NAME: hmctsprod
 
 jobs:
   publish:
@@ -17,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
 
     steps:
       - name: Checkout code
@@ -27,11 +29,15 @@ jobs:
         with:
           version: 'v3.14.0'
 
-      - name: Login to Helm OCI registry
-        run: |
-          echo "${{ secrets.REGISTRY_PASSWORD }}" | \
-            helm registry login ${{ env.REGISTRY }} \
-              --username "${{ secrets.REGISTRY_USERNAME }}" --password-stdin
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      - name: ACR login
+        run: az acr login --name ${{ env.REGISTRY_NAME }}
 
       - name: Add Bitnami repo
         run: helm repo add bitnami https://charts.bitnami.com/bitnami

--- a/.github/workflows/job.helm-publish.yml
+++ b/.github/workflows/job.helm-publish.yml
@@ -9,7 +9,7 @@ on:
         description: "Short git SHA for chart version suffix"
 
 env:
-  REGISTRY: hmctspublic.azurecr.io
+  REGISTRY: hmctsprod.azurecr.io
 
 jobs:
   publish:

--- a/.github/workflows/job.promote-images.yml
+++ b/.github/workflows/job.promote-images.yml
@@ -17,7 +17,7 @@ on:
         description: "JSON array of all Helm apps"
 
 env:
-  REGISTRY: hmctspublic.azurecr.io
+  REGISTRY: hmctsprod.azurecr.io
 
 jobs:
   promote:

--- a/.github/workflows/job.promote-images.yml
+++ b/.github/workflows/job.promote-images.yml
@@ -18,6 +18,7 @@ on:
 
 env:
   REGISTRY: hmctsprod.azurecr.io
+  REGISTRY_NAME: hmctsprod
 
 jobs:
   promote:
@@ -62,12 +63,15 @@ jobs:
           echo "registry-prefix=${registry_prefix}" >> "$GITHUB_OUTPUT"
           echo "Registry prefix: ${registry_prefix}"
 
-      - name: Login to ACR
-        uses: docker/login-action@v4
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      - name: ACR login
+        run: az acr login --name ${{ env.REGISTRY_NAME }}
 
       - name: Promote image to prod and latest
         run: |

--- a/.github/workflows/job.promote-images.yml
+++ b/.github/workflows/job.promote-images.yml
@@ -18,7 +18,6 @@ on:
 
 env:
   REGISTRY: hmctsprod.azurecr.io
-  REGISTRY_NAME: hmctsprod
 
 jobs:
   promote:
@@ -71,7 +70,7 @@ jobs:
           allow-no-subscriptions: true
 
       - name: ACR login
-        run: az acr login --name ${{ env.REGISTRY_NAME }}
+        run: az acr login --name "${REGISTRY%.azurecr.io}"
 
       - name: Promote image to prod and latest
         run: |

--- a/.github/workflows/jobs/build-and-publish-images/README.md
+++ b/.github/workflows/jobs/build-and-publish-images/README.md
@@ -22,7 +22,7 @@ Detects which applications have been affected by code changes using Turborepo, t
 |------|----------|-------------|
 | `CHANGE_ID` | Auto | PR number (set from `inputs.change-id`) |
 | `SHORT_SHA` | Auto | Git SHA (set automatically from `github.sha`) |
-| `REGISTRY` | Auto | Container registry URL (`hmctspublic.azurecr.io`) |
+| `REGISTRY` | Auto | Container registry URL (`hmctsprod.azurecr.io`) |
 
 ## Secrets
 

--- a/.github/workflows/jobs/helm-publish/README.md
+++ b/.github/workflows/jobs/helm-publish/README.md
@@ -39,6 +39,6 @@ helm/expressjs-monorepo-template/     (umbrella)
 
 ## Registry
 
-- **Registry**: `hmctspublic.azurecr.io`
-- **Chart location**: `oci://hmctspublic.azurecr.io/helm/expressjs-monorepo-template`
-- **Pull example**: `helm pull oci://hmctspublic.azurecr.io/helm/expressjs-monorepo-template --version 0.0.1-abc1234`
+- **Registry**: `hmctsprod.azurecr.io`
+- **Chart location**: `oci://hmctsprod.azurecr.io/helm/expressjs-monorepo-template`
+- **Pull example**: `helm pull oci://hmctsprod.azurecr.io/helm/expressjs-monorepo-template --version 0.0.1-abc1234`

--- a/.github/workflows/jobs/promote-images/README.md
+++ b/.github/workflows/jobs/promote-images/README.md
@@ -67,11 +67,11 @@ Promote Stage:   prod-{sha}   (immutable, for traceability/rollback)
 ```
 Promote Stage:   Package umbrella chart as 0.0.1-{sha}
                       |
-                 Push to oci://hmctspublic.azurecr.io/helm
+                 Push to oci://hmctsprod.azurecr.io/helm
 ```
 
 ## Registry
 
-- **Registry**: `hmctspublic.azurecr.io`
+- **Registry**: `hmctsprod.azurecr.io`
 - **Image Format**: `{team}/{app-name}:{tag}`
-- **Chart Format**: `oci://hmctspublic.azurecr.io/helm/expressjs-monorepo-template:{version}`
+- **Chart Format**: `oci://hmctsprod.azurecr.io/helm/expressjs-monorepo-template:{version}`

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,5 +1,5 @@
 # ---- Base image ----
-FROM hmctspublic.azurecr.io/base/node:22-alpine AS base
+FROM hmctsprod.azurecr.io/base/node:22-alpine AS base
 USER root
 RUN npm install -g corepack
 RUN corepack enable

--- a/apps/api/helm/Chart.yaml
+++ b/apps/api/helm/Chart.yaml
@@ -9,4 +9,4 @@ version: 0.0.1
 dependencies:
   - name: nodejs
     version: 3.2.0
-    repository: 'oci://hmctspublic.azurecr.io/helm'
+    repository: 'oci://hmctsprod.azurecr.io/helm'

--- a/apps/api/helm/values.yaml
+++ b/apps/api/helm/values.yaml
@@ -3,7 +3,7 @@ nodejs:
   applicationPort: 3001
   aadIdentityName: dtsse
   ingressHost: expressjs-monorepo-template-api.{{ .Values.global.environment }}.platform.hmcts.net
-  image: 'hmctspublic.azurecr.io/dtsse/expressjs-monorepo-template-api:latest'
+  image: 'hmctsprod.azurecr.io/dtsse/expressjs-monorepo-template-api:latest'
   environment:
     EXAMPLE_ENV: example
   keyVaults:

--- a/apps/crons/Dockerfile
+++ b/apps/crons/Dockerfile
@@ -1,5 +1,5 @@
 # ---- Base image ----
-FROM hmctspublic.azurecr.io/base/node:22-alpine AS base
+FROM hmctsprod.azurecr.io/base/node:22-alpine AS base
 USER root
 RUN npm install -g corepack
 RUN corepack enable

--- a/apps/crons/helm/Chart.yaml
+++ b/apps/crons/helm/Chart.yaml
@@ -9,4 +9,4 @@ version: 0.0.1
 dependencies:
   - name: job
     version: 2.2.0
-    repository: 'oci://hmctspublic.azurecr.io/helm'
+    repository: 'oci://hmctsprod.azurecr.io/helm'

--- a/apps/crons/helm/values.yaml
+++ b/apps/crons/helm/values.yaml
@@ -5,7 +5,7 @@ global:
 job:
   releaseNameOverride: "{{ .Release.Name }}-crons"
   disableActiveClusterCheck: true
-  image: hmctspublic.azurecr.io/dtsse/expressjs-monorepo-template-crons:latest
+  image: hmctsprod.azurecr.io/dtsse/expressjs-monorepo-template-crons:latest
   aadIdentityName: dtsse
   environment:
     SCRIPT_NAME: 'example'

--- a/apps/postgres/Dockerfile
+++ b/apps/postgres/Dockerfile
@@ -1,5 +1,5 @@
 # ---- Base image ----
-FROM hmctspublic.azurecr.io/base/node:22-alpine AS base
+FROM hmctsprod.azurecr.io/base/node:22-alpine AS base
 USER root
 RUN npm install -g corepack
 RUN corepack enable

--- a/apps/postgres/README.md
+++ b/apps/postgres/README.md
@@ -104,7 +104,7 @@ Configure via Flux/ArgoCD to:
 nodejs:
   releaseNameOverride: "{{ .Release.Name }}-postgres"
   applicationPort: 5555  # Health proxy port (proxies to Studio on 5556)
-  image: hmctspublic.azurecr.io/dtsse/expressjs-monorepo-template-postgres:latest
+  image: hmctsprod.azurecr.io/dtsse/expressjs-monorepo-template-postgres:latest
   ingressHost: expressjs-monorepo-template-postgres.{{ .Values.global.environment }}.platform.hmcts.net
   # Uses default HTTP health checks provided by nodejs chart
 ```

--- a/apps/postgres/helm/Chart.yaml
+++ b/apps/postgres/helm/Chart.yaml
@@ -9,4 +9,4 @@ version: 0.0.1
 dependencies:
   - name: nodejs
     version: 3.2.0
-    repository: 'oci://hmctspublic.azurecr.io/helm'
+    repository: 'oci://hmctsprod.azurecr.io/helm'

--- a/apps/postgres/helm/values.yaml
+++ b/apps/postgres/helm/values.yaml
@@ -3,7 +3,7 @@ nodejs:
   applicationPort: 5555
   aadIdentityName: dtsse
   ingressHost: expressjs-monorepo-template-postgres.{{ .Values.global.environment }}.platform.hmcts.net
-  image: 'hmctspublic.azurecr.io/dtsse/expressjs-monorepo-template-postgres:latest'
+  image: 'hmctsprod.azurecr.io/dtsse/expressjs-monorepo-template-postgres:latest'
   environment:
     POSTGRES_DATABASE: expressjs-monorepo-template
   keyVaults:

--- a/apps/postgres/start.sh
+++ b/apps/postgres/start.sh
@@ -28,7 +28,7 @@ if [ -d "/mnt/secrets" ]; then
 fi 
 
 echo "Running database migrations..."
-npx prisma migrate deploy --schema=./dist/schema.prisma
+npx prisma migrate deploy --config=./prisma.config.ts
 
 if [ $? -eq 0 ]; then
   echo "Migrations completed successfully"

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,5 +1,5 @@
 # ---- Base image ----
-FROM hmctspublic.azurecr.io/base/node:22-alpine AS base
+FROM hmctsprod.azurecr.io/base/node:22-alpine AS base
 USER root
 RUN npm install -g corepack
 RUN corepack enable

--- a/apps/web/helm/Chart.yaml
+++ b/apps/web/helm/Chart.yaml
@@ -9,4 +9,4 @@ version: 0.0.1
 dependencies:
   - name: nodejs
     version: 3.2.0
-    repository: 'oci://hmctspublic.azurecr.io/helm'
+    repository: 'oci://hmctsprod.azurecr.io/helm'

--- a/apps/web/helm/values.yaml
+++ b/apps/web/helm/values.yaml
@@ -3,7 +3,7 @@ nodejs:
   applicationPort: 3000
   aadIdentityName: dtsse
   ingressHost: expressjs-monorepo-template-web.{{ .Values.global.environment }}.platform.hmcts.net
-  image: 'hmctspublic.azurecr.io/dtsse/expressjs-monorepo-template-web:latest'
+  image: 'hmctsprod.azurecr.io/dtsse/expressjs-monorepo-template-web:latest'
   environment:
     POSTGRES_DATABASE: expressjs-monorepo-template
   keyVaults:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -381,7 +381,7 @@ Automated preview environments are created for each pull request, allowing teams
 **Shared Resources**:
 - Azure Flexible PostgreSQL Server: `dtsse-preview`
 - AKS Cluster: `cft-preview-01-aks`
-- Azure Container Registry: `hmctspublic.azurecr.io`
+- Azure Container Registry: `hmctsprod.azurecr.io`
 
 ### Cleanup
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -17,7 +17,7 @@ The application is deployed to Azure Kubernetes Service (AKS) using Helm charts.
 
 - **Azure Portal**: Access to HMCTS Azure subscription
 - **AKS Cluster**: kubectl credentials for target cluster
-- **Container Registry**: Push access to `hmctspublic.azurecr.io`
+- **Container Registry**: Push access to `hmctsprod.azurecr.io`
 - **GitHub**: Repository write access for workflow triggers
 
 ### Tools Required
@@ -67,7 +67,7 @@ apps/{app}/helm/
 | `expressjs-monorepo-template-api` | Local (`apps/api/helm`) | REST API |
 | `expressjs-monorepo-template-crons` | Local (`apps/crons/helm`) | Scheduled jobs |
 | `expressjs-monorepo-template-postgres` | Local (`apps/postgres/helm`) | Database migrations |
-| `postgresql` | `oci://hmctspublic.azurecr.io/helm` | PostgreSQL database |
+| `postgresql` | `oci://hmctsprod.azurecr.io/helm` | PostgreSQL database |
 | `redis` | Bitnami | Cache layer |
 
 ## Environment Configuration
@@ -279,11 +279,11 @@ If automated deployment fails:
 
 ```bash
 # 1. Build image locally
-docker build -t hmctspublic.azurecr.io/dtsse/app:manual \
+docker build -t hmctsprod.azurecr.io/dtsse/app:manual \
   -f apps/web/Dockerfile .
 
 # 2. Push to registry
-docker push hmctspublic.azurecr.io/dtsse/app:manual
+docker push hmctsprod.azurecr.io/dtsse/app:manual
 
 # 3. Deploy with Helm
 cd helm/expressjs-monorepo-template
@@ -291,7 +291,7 @@ helm dependency update
 helm upgrade --install {release-name} . \
   --namespace {namespace} \
   --values values.yaml \
-  --set web.nodejs.image=hmctspublic.azurecr.io/dtsse/app:manual \
+  --set web.nodejs.image=hmctsprod.azurecr.io/dtsse/app:manual \
   --wait \
   --timeout 10m
 ```
@@ -348,7 +348,7 @@ If a specific image version needs to be reverted:
 # Update image tag
 helm upgrade {release-name} . \
   --namespace {namespace} \
-  --set web.nodejs.image=hmctspublic.azurecr.io/dtsse/app:previous-tag \
+  --set web.nodejs.image=hmctsprod.azurecr.io/dtsse/app:previous-tag \
   --reuse-values
 ```
 

--- a/helm/expressjs-monorepo-template/Chart.yaml
+++ b/helm/expressjs-monorepo-template/Chart.yaml
@@ -29,5 +29,5 @@ dependencies:
     condition: redis.enabled
   - name: postgresql
     version: 1.1.0
-    repository: oci://hmctspublic.azurecr.io/helm
+    repository: oci://hmctsprod.azurecr.io/helm
     condition: postgresql.enabled

--- a/helm/expressjs-monorepo-template/values.preview.template.yaml
+++ b/helm/expressjs-monorepo-template/values.preview.template.yaml
@@ -17,7 +17,7 @@ crons:
 # Web application configuration
 expressjs-monorepo-template-web:
   nodejs:
-    image: "hmctspublic.azurecr.io/dtsse/expressjs-monorepo-template-web:${WEB_IMAGE}"
+    image: "hmctsprod.azurecr.io/dtsse/expressjs-monorepo-template-web:${WEB_IMAGE}"
     ingressHost: "${TEAM_NAME}-{{ .Release.Name }}-web.preview.platform.hmcts.net"
     environment:
       REDIS_URL: "redis://{{ .Release.Name }}-redis-master:6379"
@@ -39,7 +39,7 @@ expressjs-monorepo-template-web:
 # API application configuration
 expressjs-monorepo-template-api:
   nodejs:
-    image: "hmctspublic.azurecr.io/dtsse/expressjs-monorepo-template-api:${API_IMAGE}"
+    image: "hmctsprod.azurecr.io/dtsse/expressjs-monorepo-template-api:${API_IMAGE}"
     ingressHost: "${TEAM_NAME}-{{ .Release.Name }}-api.preview.platform.hmcts.net"
     environment:
       POSTGRES_DATABASE: "{{ .Release.Name }}"
@@ -60,7 +60,7 @@ expressjs-monorepo-template-api:
 # Crons application configuration
 expressjs-monorepo-template-crons:
   job:
-    image: "hmctspublic.azurecr.io/dtsse/expressjs-monorepo-template-crons:${CRONS_IMAGE}"
+    image: "hmctsprod.azurecr.io/dtsse/expressjs-monorepo-template-crons:${CRONS_IMAGE}"
     schedule: "*/5 * * * *"  # Every 5 minutes
     suspend: false
     kind: CronJob
@@ -84,7 +84,7 @@ expressjs-monorepo-template-crons:
 # Postgres Prisma Studio service configuration
 expressjs-monorepo-template-postgres:
   nodejs:
-    image: "hmctspublic.azurecr.io/dtsse/expressjs-monorepo-template-postgres:${POSTGRES_IMAGE}"
+    image: "hmctsprod.azurecr.io/dtsse/expressjs-monorepo-template-postgres:${POSTGRES_IMAGE}"
     ingressHost: "${TEAM_NAME}-{{ .Release.Name }}-postgres.preview.platform.hmcts.net"
     environment:
       POSTGRES_DATABASE: "{{ .Release.Name }}"
@@ -122,5 +122,5 @@ redis:
   replica:
     replicaCount: 0
   image:
-    registry: hmctspublic.azurecr.io
+    registry: hmctsprod.azurecr.io
     repository: imported/bitnami/redis

--- a/helm/expressjs-monorepo-template/values.template.yaml
+++ b/helm/expressjs-monorepo-template/values.template.yaml
@@ -16,19 +16,19 @@ crons:
 # Web application configuration
 expressjs-monorepo-template-web:
   nodejs:
-    image: "hmctspublic.azurecr.io/dtsse/expressjs-monorepo-template-web:${WEB_IMAGE}"
+    image: "hmctsprod.azurecr.io/dtsse/expressjs-monorepo-template-web:${WEB_IMAGE}"
     ingressHost: "${TEAM_NAME}-{{ .Release.Name }}-web.${ENVIRONMENT}.platform.hmcts.net"
 
 # API application configuration
 expressjs-monorepo-template-api:
   nodejs:
-    image: "hmctspublic.azurecr.io/dtsse/expressjs-monorepo-template-api:${API_IMAGE}"
+    image: "hmctsprod.azurecr.io/dtsse/expressjs-monorepo-template-api:${API_IMAGE}"
     ingressHost: "${TEAM_NAME}-{{ .Release.Name }}-api.${ENVIRONMENT}.platform.hmcts.net"
 
 # Crons application configuration
 expressjs-monorepo-template-crons:
   job:
-    image: "hmctspublic.azurecr.io/dtsse/expressjs-monorepo-template-crons:${CRONS_IMAGE}"
+    image: "hmctsprod.azurecr.io/dtsse/expressjs-monorepo-template-crons:${CRONS_IMAGE}"
     schedule: "*/5 * * * *"
     suspend: false
     kind: CronJob
@@ -36,7 +36,7 @@ expressjs-monorepo-template-crons:
 # Postgres Prisma Studio service configuration
 expressjs-monorepo-template-postgres:
   nodejs:
-    image: "hmctspublic.azurecr.io/dtsse/expressjs-monorepo-template-postgres:${POSTGRES_IMAGE}"
+    image: "hmctsprod.azurecr.io/dtsse/expressjs-monorepo-template-postgres:${POSTGRES_IMAGE}"
     ingressHost: "${TEAM_NAME}-{{ .Release.Name }}-postgres.${ENVIRONMENT}.platform.hmcts.net"
 
 # Dev dependencies - DISABLED for AAT/Prod (managed by Terraform)


### PR DESCRIPTION
## Summary
- Rewires every image reference from `hmctspublic.azurecr.io` to `hmctsprod.azurecr.io` — Dockerfile bases, per-app Helm `image:` defaults, OCI chart dependencies, env templates (incl. the Bitnami Redis import in `values.preview.template.yaml`), and the four GitHub Actions workflow `REGISTRY` env vars.
- Refreshes the live docs (`docs/DEPLOYMENT.md`, `docs/ARCHITECTURE.md`, `apps/postgres/README.md`, the three `.github/workflows/jobs/*/README.md` files) and the `.claude/agents/infrastructure-engineer.md` example snippets to match.
- Leaves `docs/tickets/VIBE-119/*` intentionally untouched — those are the historical ticket record.
- Auth is unchanged: existing OIDC (`AZURE_CLIENT_ID` / `AZURE_TENANT_ID`) and `REGISTRY_USERNAME` / `REGISTRY_PASSWORD` secrets already grant access to the new ACR.

## Test plan
- [ ] `build-and-publish-images` workflow pushes to `hmctsprod.azurecr.io` successfully
- [ ] `helm-publish` workflow logs into and pushes the umbrella chart to `oci://hmctsprod.azurecr.io/helm`
- [ ] `helm-deploy` to preview pulls all four app images + the Redis chart from `hmctsprod`
- [ ] `promote-images` succeeds end-to-end on merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Migrated container registry references from public to production endpoints across all infrastructure configurations, Dockerfiles, and Helm charts.
  * Updated deployment workflows to use Azure OIDC-based authentication instead of legacy registry credentials for enhanced security.

* **Documentation**
  * Updated deployment guides and architecture documentation to reflect new production registry endpoints.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmcts/expressjs-monorepo-template/pull/624)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->