### PR TITLE
test: pin release workflow to library fix branch

### DIFF
--- a/.github/workflows/workflow.release.yml
+++ b/.github/workflows/workflow.release.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   release:
-    uses: hmcts/cnp-githubactions-library/.github/workflows/npm-changesets-release.yaml@main
+    uses: hmcts/cnp-githubactions-library/.github/workflows/npm-changesets-release.yaml@fix/npm-token-optional
     with:
       node-version-file: '.nvmrc'
       version-command: 'yarn version-packages'


### PR DESCRIPTION
## Purpose
Temporary — end-to-end test of the [`NPM_TOKEN` → `NPM_API_TOKEN` rename](https://github.com/hmcts/cnp-githubactions-library/pull/14) before that library PR merges.

## What changes
One-line: pin the library `uses:` ref from `@main` to `@fix/npm-token-optional`.

```diff
- uses: hmcts/cnp-githubactions-library/.github/workflows/npm-changesets-release.yaml@main
+ uses: hmcts/cnp-githubactions-library/.github/workflows/npm-changesets-release.yaml@fix/npm-token-optional
```

## What we expect after merging this
The Release workflow on master fires. With no pending `.changeset/*.md` files, it should:
1. Load without the previous `Secret NPM_TOKEN is required, but not provided` error (the rename makes `secrets: inherit` pick up the org's `NPM_API_TOKEN`).
2. Run `changesets/action@v1`, observe no pending changesets, and exit cleanly without opening a Version Packages PR or publishing.

## Revert
Once `hmcts/cnp-githubactions-library#14` is merged, open a follow-up PR (or a one-line commit) restoring `@main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration to use an alternative version of the shared npm release workflow.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmcts/expressjs-monorepo-template/pull/632)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->