### PR TITLE
test: drop provenance for first-publish diagnostic

### DIFF
--- a/libs/simple-router/package.json
+++ b/libs/simple-router/package.json
@@ -22,8 +22,7 @@
     }
   },
   "publishConfig": {
-    "access": "public",
-    "provenance": true
+    "access": "public"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Diagnostic for the npm `E404 Not Found` on first publish of `@hmcts/simple-router`. If provenance was the blocker, this run should succeed. If it still 404s, the automation token can't create new packages under `@hmcts` and we need an org owner to pre-create the package (or a granular token with create-new-package rights).

Once we know the cause, this either reverts (provenance was fine, real issue is elsewhere) or re-introduces provenance after the package exists.