### PR TITLE
feat: publish @hmcts-cft/simple-router to Azure Artifacts

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -1,8 +1,8 @@
 # Changesets
 
-This repository uses [Changesets](https://github.com/changesets/changesets) to manage versioning and publishing of public libraries to npm.
+This repository uses [Changesets](https://github.com/changesets/changesets) to manage versioning and publishing of libraries to the HMCTS Azure Artifacts `hmcts-lib` feed.
 
-Currently the only library published from this monorepo is **`@hmcts/simple-router`**. Other libraries under `libs/` are workspace-only — see the `ignore` list in `config.json` for the current scope.
+Currently the only library published from this monorepo is **`@hmcts-cft/simple-router`**. Other libraries under `libs/` are workspace-only — see the `ignore` list in `config.json` for the current scope.
 
 ## Releasing a change
 
@@ -22,14 +22,13 @@ Currently the only library published from this monorepo is **`@hmcts/simple-rout
 On merge to `master`:
 
 - The Release workflow (`.github/workflows/workflow.release.yml`) consumes pending changesets and opens (or updates) a **"chore: version packages"** pull request that bumps the affected `package.json` versions and writes changelogs.
-- When a maintainer merges that PR, the workflow re-runs, publishes the new versions to npm with provenance attestation, and creates a GitHub release.
+- When a maintainer merges that PR, the workflow re-runs, publishes the new versions to the Azure Artifacts feed, and creates a GitHub release.
 
 ## Onboarding a new library
 
 To start publishing a library currently in the `ignore` list:
 
 1. Remove its package name from `ignore` in `config.json`.
-2. Make sure the library's `package.json` has: `description`, `license`, `repository` (with `directory`), `files`, `exports`, and `publishConfig: { "access": "public", "provenance": true }` — see `libs/simple-router/package.json` for the canonical shape.
-3. Create the first changeset for it and merge.
-
-The `name` field must be unique on npm and use the `@hmcts/` scope.
+2. Make sure the library's `package.json` has: `description`, `license`, `repository` (with `directory`), `files`, `exports`, and `publishConfig: { "registry": "https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/npm/registry/" }` — see `libs/simple-router/package.json` for the canonical shape.
+3. Rename it under the `@hmcts-cft` scope (the public `@hmcts` scope on npmjs.org is unrelated and not used here).
+4. Create the first changeset for it and merge.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "public",
+  "access": "restricted",
   "baseBranch": "master",
   "updateInternalDependencies": "patch",
   "ignore": [],

--- a/.changeset/publish-to-azure-artifacts.md
+++ b/.changeset/publish-to-azure-artifacts.md
@@ -1,0 +1,5 @@
+---
+"@hmcts-cft/simple-router": major
+---
+
+Rename `@hmcts/simple-router` to `@hmcts-cft/simple-router` and publish to the HMCTS Azure Artifacts `hmcts-lib` feed instead of public npm. The previous `@hmcts` scope on npmjs.org was never successfully populated; the CFT-allocated `@hmcts-cft` scope on Azure Artifacts is the canonical home going forward. Consumers must update their imports and add an `.npmrc` scope-mapping for `@hmcts-cft` to the Azure feed.

--- a/.github/workflows/workflow.release.yml
+++ b/.github/workflows/workflow.release.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   release:
-    uses: hmcts/cnp-githubactions-library/.github/workflows/npm-changesets-release.yaml@fix/npm-token-optional
+    uses: hmcts/cnp-githubactions-library/.github/workflows/npm-changesets-release.yaml@main
     with:
       node-version-file: '.nvmrc'
       version-command: 'yarn version-packages'

--- a/README.md
+++ b/README.md
@@ -159,20 +159,32 @@ yarn db:drop                    # Drop all tables and reset the database
 yarn changeset                  # Declare a version bump for a published library
 ```
 
-### Releasing a library to npm
+### Releasing a library
 
-`@hmcts/simple-router` is published to npm. To ship a change:
+`@hmcts-cft/simple-router` is published to the HMCTS Azure Artifacts `hmcts-lib` feed (the same feed Gradle artifacts publish to). To ship a change:
 
 1. Make your code change in `libs/simple-router/`.
 2. Run `yarn changeset` and follow the prompts (pick the package, bump type, write a one-line summary).
 3. Commit the generated `.changeset/*.md` file alongside your code change.
 4. Open and merge your PR as usual.
 
-The Release workflow (`.github/workflows/workflow.release.yml`) opens a "Version Packages" PR collecting pending changesets. Merging that PR publishes to npm with provenance attestation and creates a GitHub release.
+The Release workflow (`.github/workflows/workflow.release.yml`) opens a "Version Packages" PR collecting pending changesets. Merging that PR publishes to Azure Artifacts and creates a GitHub release.
 
-The release plumbing lives in [`hmcts/cnp-githubactions-library`](https://github.com/hmcts/cnp-githubactions-library) (`npm-changesets-release`) — this repo just invokes the reusable workflow with `secrets: inherit`.
+The release plumbing lives in [`hmcts/cnp-githubactions-library`](https://github.com/hmcts/cnp-githubactions-library) (`npm-changesets-release`) — this repo just invokes the reusable workflow with `secrets: inherit`. Auth uses the org-level `AZURE_DEVOPS_ARTIFACT_USERNAME` / `AZURE_DEVOPS_ARTIFACT_TOKEN` pair (same pair Gradle publishes use).
 
-Other libraries (`cloud-native-platform`, `express-govuk-starter`, `onboarding`) are marked `private: true` and are workspace-only today. To publish one, drop the `"private": true` flag, add the same `publishConfig` / `files` / `license` / `repository` fields to its `package.json` as `simple-router` has, and create a changeset for it.
+#### Installing the published library in another repo
+
+```ini
+# .npmrc
+@hmcts-cft:registry=https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/npm/registry/
+//pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/npm/registry/:username=hmcts
+//pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/npm/registry/:_password=${AZURE_DEVOPS_ARTIFACT_TOKEN_BASE64}
+//pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/npm/registry/:email=npm@hmcts.net
+```
+
+`AZURE_DEVOPS_ARTIFACT_TOKEN_BASE64` is the base64 encoding of a PAT with `Packaging (Read)` on the `hmcts-lib` feed (`printf %s "$PAT" | base64`).
+
+Other libraries (`cloud-native-platform`, `express-govuk-starter`, `onboarding`) are marked `private: true` and are workspace-only today. To publish one, drop the `"private": true` flag, rename it under the `@hmcts-cft` scope, add the same `publishConfig.registry` / `files` / `license` / `repository` fields to its `package.json` as `simple-router` has, and create a changeset for it.
 
 ### Creating a New Feature Module
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,10 +14,10 @@
     "lint:fix": "biome check --write ."
   },
   "dependencies": {
+    "@hmcts-cft/simple-router": "workspace:*",
     "@hmcts/cloud-native-platform": "workspace:*",
     "@hmcts/onboarding": "workspace:*",
     "@hmcts/postgres-prisma": "workspace:*",
-    "@hmcts/simple-router": "workspace:*",
     "compression": "1.8.1",
     "config": "4.4.1",
     "cors": "2.8.6",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -2,7 +2,7 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { getPropertiesVolumeSecrets, healthcheck, monitoringMiddleware } from "@hmcts/cloud-native-platform";
-import { createSimpleRouter } from "@hmcts/simple-router";
+import { createSimpleRouter } from "@hmcts-cft/simple-router";
 import compression from "compression";
 import cors from "cors";
 import type { Express } from "express";

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,12 +19,12 @@
     "lint:fix": "biome check --write ."
   },
   "dependencies": {
+    "@hmcts-cft/simple-router": "workspace:*",
     "@hmcts/cloud-native-platform": "workspace:*",
     "@hmcts/cookie-manager": "1.1.0",
     "@hmcts/express-govuk-starter": "workspace:*",
     "@hmcts/onboarding": "workspace:*",
     "@hmcts/postgres-prisma": "workspace:*",
-    "@hmcts/simple-router": "workspace:*",
     "config": "4.4.1",
     "connect-redis": "9.0.0",
     "cookie-parser": "1.4.7",

--- a/apps/web/src/app.ts
+++ b/apps/web/src/app.ts
@@ -10,7 +10,7 @@ import {
   expressSessionRedis,
   notFoundHandler
 } from "@hmcts/express-govuk-starter";
-import { createSimpleRouter } from "@hmcts/simple-router";
+import { createSimpleRouter } from "@hmcts-cft/simple-router";
 import cookieParser from "cookie-parser";
 import type { Express } from "express";
 import express from "express";

--- a/libs/simple-router/package.json
+++ b/libs/simple-router/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@hmcts/simple-router",
+  "name": "@hmcts-cft/simple-router",
   "version": "1.0.0",
   "description": "Lightweight file-system router for Express, inspired by Next.js routing.",
   "license": "MIT",
@@ -22,7 +22,7 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "registry": "https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/npm/registry/"
   },
   "scripts": {
     "build": "tsc",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
       "@hmcts/web": ["./apps/web/src"],
       "@hmcts/express-govuk-starter": ["./libs/express-govuk-starter/src"],
       "@hmcts/cloud-native-platform": ["./libs/cloud-native-platform/src"],
-      "@hmcts/simple-router": ["./libs/simple-router/src"],
+      "@hmcts-cft/simple-router": ["./libs/simple-router/src"],
       "@hmcts/onboarding": ["./libs/onboarding/src"]
     },
     "esModuleInterop": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1032,14 +1032,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@hmcts-cft/simple-router@workspace:*, @hmcts-cft/simple-router@workspace:libs/simple-router":
+  version: 0.0.0-use.local
+  resolution: "@hmcts-cft/simple-router@workspace:libs/simple-router"
+  dependencies:
+    "@types/express": "npm:5.0.6"
+  peerDependencies:
+    express: ^5.1.0
+  languageName: unknown
+  linkType: soft
+
 "@hmcts/api@workspace:apps/api":
   version: 0.0.0-use.local
   resolution: "@hmcts/api@workspace:apps/api"
   dependencies:
+    "@hmcts-cft/simple-router": "workspace:*"
     "@hmcts/cloud-native-platform": "workspace:*"
     "@hmcts/onboarding": "workspace:*"
     "@hmcts/postgres-prisma": "workspace:*"
-    "@hmcts/simple-router": "workspace:*"
     "@types/compression": "npm:1.8.1"
     "@types/config": "npm:4.4.0"
     "@types/cors": "npm:2.8.19"
@@ -1156,26 +1166,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@hmcts/simple-router@workspace:*, @hmcts/simple-router@workspace:libs/simple-router":
-  version: 0.0.0-use.local
-  resolution: "@hmcts/simple-router@workspace:libs/simple-router"
-  dependencies:
-    "@types/express": "npm:5.0.6"
-  peerDependencies:
-    express: ^5.1.0
-  languageName: unknown
-  linkType: soft
-
 "@hmcts/web@workspace:apps/web":
   version: 0.0.0-use.local
   resolution: "@hmcts/web@workspace:apps/web"
   dependencies:
+    "@hmcts-cft/simple-router": "workspace:*"
     "@hmcts/cloud-native-platform": "workspace:*"
     "@hmcts/cookie-manager": "npm:1.1.0"
     "@hmcts/express-govuk-starter": "workspace:*"
     "@hmcts/onboarding": "workspace:*"
     "@hmcts/postgres-prisma": "workspace:*"
-    "@hmcts/simple-router": "workspace:*"
     "@types/config": "npm:4.4.0"
     "@types/cookie-parser": "npm:1.4.10"
     "@types/express": "npm:5.0.6"


### PR DESCRIPTION
## Summary
- Rename `@hmcts/simple-router` → `@hmcts-cft/simple-router`, point `publishConfig.registry` at the HMCTS Azure Artifacts `hmcts-lib` feed.
- Re-pin the release workflow to `cnp-githubactions-library@main` now that the Azure Artifacts rewrite has landed there (see hmcts/cnp-githubactions-library#15).
- Update internal imports, tsconfig path mapping, both consumer apps, `.changeset/` docs + config, and the README contributor / consumer instructions.
- Add a `major`-bump changeset for the rename so the merge triggers a Version Packages PR → publish.

## Why

The previous public-npm path never landed a successful publish (#633). The npmjs `@hmcts` automation token can't create new packages under that scope, and HMCTS publishes Java to the Azure Artifacts `hmcts-lib` feed already with the existing `AZURE_DEVOPS_ARTIFACT_USERNAME` / `AZURE_DEVOPS_ARTIFACT_TOKEN` org-level secrets. The `feature/xui-header-package` PoC in `hmcts/ccd-config-generator` proves the feed accepts npm packages with this auth pattern.

## Test plan
- [ ] On merge to master, the release workflow opens a "Version Packages" PR bumping `@hmcts-cft/simple-router` to `2.0.0`.
- [ ] On merge of that Version Packages PR, the workflow publishes to the Azure Artifacts feed.
- [ ] Confirm `@hmcts-cft/simple-router@2.0.0` appears in the `hmcts-lib` feed UI.
- [ ] In a scratch directory with a PAT-authenticated `.npmrc`, `npm install @hmcts-cft/simple-router` resolves from the feed.

## Closes
Supersedes #632 / #633 (the public-npm diagnostics).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
* Renamed package to `@hmcts-cft/simple-router` with updated publishing configuration for Azure Artifacts
* Changed package access setting to restricted

**Documentation**
* Updated release and onboarding guidance to reflect Azure Artifacts as the publishing destination
* Added `.npmrc` configuration instructions for consuming the library from Azure Artifacts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmcts/expressjs-monorepo-template/pull/639)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->