### PR TITLE
feat(cloud-native-platform): add trackException and helm alias-map

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -2,7 +2,7 @@
 
 This repository uses [Changesets](https://github.com/changesets/changesets) to manage versioning and publishing of libraries to the HMCTS Azure Artifacts `hmcts-lib` feed.
 
-Currently the only library published from this monorepo is **`@hmcts-cft/simple-router`**. Other libraries under `libs/` are workspace-only — see the `ignore` list in `config.json` for the current scope.
+Libraries published from this monorepo: **`@hmcts-cft/simple-router`**, **`@hmcts-cft/cloud-native-platform`**. Other libraries under `libs/` are workspace-only (marked `"private": true` in their `package.json`).
 
 ## Releasing a change
 
@@ -26,9 +26,9 @@ On merge to `master`:
 
 ## Onboarding a new library
 
-To start publishing a library currently in the `ignore` list:
+To start publishing a workspace-only library:
 
-1. Remove its package name from `ignore` in `config.json`.
+1. Remove `"private": true` from its `package.json`.
 2. Make sure the library's `package.json` has: `description`, `license`, `repository` (with `directory`), `files`, `exports`, and `publishConfig: { "registry": "https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/npm/registry/" }` — see `libs/simple-router/package.json` for the canonical shape.
 3. Rename it under the `@hmcts-cft` scope (the public `@hmcts` scope on npmjs.org is unrelated and not used here).
 4. Create the first changeset for it and merge.

--- a/.changeset/publish-cloud-native-platform.md
+++ b/.changeset/publish-cloud-native-platform.md
@@ -1,0 +1,5 @@
+---
+"@hmcts-cft/cloud-native-platform": major
+---
+
+First publish of `@hmcts-cft/cloud-native-platform` to the HMCTS Azure Artifacts `hmcts-lib` feed. Provides health-check middleware (`/health`, `/health/liveness`, `/health/readiness`), Application Insights monitoring middleware, a free-function `trackException` helper, and properties-volume / Azure Key Vault secret loading (`getPropertiesVolumeSecrets`, `addFromAzureVault`). Previously workspace-only as `@hmcts/cloud-native-platform`; the new published name is `@hmcts-cft/cloud-native-platform`, matching the `@hmcts-cft` scope used for other libraries on the same feed. Consumers must update their imports and add an `.npmrc` scope mapping for `@hmcts-cft` to the Azure feed.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,8 +14,8 @@
     "lint:fix": "biome check --write ."
   },
   "dependencies": {
+    "@hmcts-cft/cloud-native-platform": "workspace:*",
     "@hmcts-cft/simple-router": "workspace:*",
-    "@hmcts/cloud-native-platform": "workspace:*",
     "@hmcts/onboarding": "workspace:*",
     "@hmcts/postgres-prisma": "workspace:*",
     "compression": "1.8.1",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,7 +1,7 @@
 // API Application Entry Point
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { getPropertiesVolumeSecrets, healthcheck, monitoringMiddleware } from "@hmcts/cloud-native-platform";
+import { getPropertiesVolumeSecrets, healthcheck, monitoringMiddleware } from "@hmcts-cft/cloud-native-platform";
 import { createSimpleRouter } from "@hmcts-cft/simple-router";
 import compression from "compression";
 import cors from "cors";

--- a/apps/crons/package.json
+++ b/apps/crons/package.json
@@ -14,7 +14,7 @@
     "lint:fix": "biome check --write ."
   },
   "dependencies": {
-    "@hmcts/cloud-native-platform": "workspace:*",
+    "@hmcts-cft/cloud-native-platform": "workspace:*",
     "@hmcts/postgres-prisma": "workspace:*",
     "config": "4.4.1"
   },

--- a/apps/crons/src/index.test.ts
+++ b/apps/crons/src/index.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mockGetPropertiesVolumeSecrets = vi.fn();
 const mockConfigGet = vi.fn();
 
-vi.mock("@hmcts/cloud-native-platform", () => ({
+vi.mock("@hmcts-cft/cloud-native-platform", () => ({
   getPropertiesVolumeSecrets: mockGetPropertiesVolumeSecrets
 }));
 

--- a/apps/crons/src/index.ts
+++ b/apps/crons/src/index.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { getPropertiesVolumeSecrets } from "@hmcts/cloud-native-platform";
+import { getPropertiesVolumeSecrets } from "@hmcts-cft/cloud-native-platform";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,8 +19,8 @@
     "lint:fix": "biome check --write ."
   },
   "dependencies": {
+    "@hmcts-cft/cloud-native-platform": "workspace:*",
     "@hmcts-cft/simple-router": "workspace:*",
-    "@hmcts/cloud-native-platform": "workspace:*",
     "@hmcts/cookie-manager": "1.1.0",
     "@hmcts/express-govuk-starter": "workspace:*",
     "@hmcts/onboarding": "workspace:*",

--- a/apps/web/src/app.ts
+++ b/apps/web/src/app.ts
@@ -45,10 +45,7 @@ export async function createApp(): Promise<Express> {
   app.use(
     healthcheck({
       checks: {
-        redis: hc.raw(async () => {
-          await redisConnection.ping();
-          return "UP" as const;
-        })
+        redis: hc.raw(() => redisConnection.ping())
       }
     })
   );

--- a/apps/web/src/app.ts
+++ b/apps/web/src/app.ts
@@ -1,6 +1,5 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { getPropertiesVolumeSecrets, hc, healthcheck, monitoringMiddleware } from "@hmcts/cloud-native-platform";
 import {
   configureCookieManager,
   configureGovuk,
@@ -10,6 +9,7 @@ import {
   expressSessionRedis,
   notFoundHandler
 } from "@hmcts/express-govuk-starter";
+import { getPropertiesVolumeSecrets, hc, healthcheck, monitoringMiddleware } from "@hmcts-cft/cloud-native-platform";
 import { createSimpleRouter } from "@hmcts-cft/simple-router";
 import cookieParser from "cookie-parser";
 import type { Express } from "express";

--- a/apps/web/src/app.ts
+++ b/apps/web/src/app.ts
@@ -45,7 +45,10 @@ export async function createApp(): Promise<Express> {
   app.use(
     healthcheck({
       checks: {
-        redis: hc.raw(() => redisConnection.ping())
+        redis: hc.raw(async () => {
+          await redisConnection.ping();
+          return "UP" as const;
+        })
       }
     })
   );

--- a/libs/cloud-native-platform/README.md
+++ b/libs/cloud-native-platform/README.md
@@ -1,0 +1,146 @@
+# Cloud-Native Platform helpers for Express
+
+HMCTS-flavoured helpers for running Express services on the cloud-native platform: Kubernetes-friendly health checks, Application Insights monitoring, and properties-volume / Azure Key Vault secret loading.
+
+## Install
+
+```bash
+yarn add @hmcts-cft/cloud-native-platform
+```
+
+This package is published to the HMCTS Azure Artifacts `hmcts-lib` feed. Add a scope mapping to your `.npmrc`:
+
+```
+@hmcts-cft:registry=https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/npm/registry/
+```
+
+`express` is a peer dependency. `config` is also a peer dependency, required only when using `addFromAzureVault`.
+
+## Health checks
+
+Mount the `healthcheck` middleware to expose Kubernetes-style probes at `/health`, `/health/liveness`, and `/health/readiness` (plus the bare aliases `/liveness` and `/readiness`):
+
+```typescript
+import express from "express";
+import { hc, healthcheck } from "@hmcts-cft/cloud-native-platform";
+
+const app = express();
+
+app.use(
+  healthcheck({
+    checks: {
+      redis: hc.raw(() => redisConnection.ping()),
+      upstream: hc.web("https://example-api.internal/health")
+    }
+  })
+);
+```
+
+Each endpoint returns `{ status, services }` with HTTP 200 when everything reports `"UP"` or 503 otherwise. `readinessChecks` defaults to `checks` but can be supplied separately for stricter readiness gating.
+
+### Check builders
+
+- **`hc.up()` / `hc.down()`** — constant checks, mostly for tests.
+- **`hc.web(url, timeout = 10000)`** — passes if a GET to `url` returns 2xx within `timeout` ms.
+- **`hc.raw(check)`** — wraps an arbitrary check function. Returns `"DOWN"` if it throws; any non-`"DOWN"` resolution (including `void`, strings, `Promise<string>` from `redis.ping()`) counts as `"UP"`. Return `"DOWN"` explicitly to fail without throwing.
+
+## Application Insights monitoring
+
+`monitoringMiddleware` initialises Application Insights and tracks every request as a dependency:
+
+```typescript
+import { monitoringMiddleware } from "@hmcts-cft/cloud-native-platform";
+
+app.use(
+  monitoringMiddleware({
+    serviceName: "my-service",
+    connectionString: process.env.APPLICATIONINSIGHTS_CONNECTION_STRING ?? "",
+    enabled: process.env.NODE_ENV === "production"
+  })
+);
+```
+
+If `enabled` is false (e.g. local dev) the middleware is a no-op.
+
+### `trackException`
+
+For route handlers that don't have a `MonitoringService` instance to hand:
+
+```typescript
+import { trackException } from "@hmcts-cft/cloud-native-platform";
+
+try {
+  await doRiskyThing();
+} catch (error) {
+  trackException(error as Error, { userId, area: "checkout" });
+  throw error;
+}
+```
+
+Calls `appInsights.defaultClient.trackException` when AI is initialised; falls back to `console.error` otherwise. Safe to call before `monitoringMiddleware` has run (it just logs).
+
+## Properties volume / Azure Key Vault secrets
+
+`getPropertiesVolumeSecrets` loads secrets from:
+
+- The CSI driver mount at `/mnt/secrets` (default) in deployed environments, or
+- An Azure Key Vault directly when a Helm chart path is supplied locally (non-production only).
+
+```typescript
+import { getPropertiesVolumeSecrets } from "@hmcts-cft/cloud-native-platform";
+
+await getPropertiesVolumeSecrets({
+  chartPath: "./charts/my-service/values.yaml",  // optional: enables local Azure Vault loading
+  injectEnvVars: true                            // default: also writes each secret to process.env
+});
+```
+
+### Mount-point layout
+
+Secrets mounted under `/mnt/secrets/<vault-name>/<secret-name>` are loaded as `<vault-name>.<secret-name>` keys, and (if `injectEnvVars`) injected to `process.env` under either `<secret-name>` or — if a Helm `alias` is set — the alias:
+
+```yaml
+# values.yaml
+keyVaults:
+  my-service:
+    secrets:
+      - name: redis-url          # → process.env["redis-url"]
+      - name: app-key            # → process.env["APP_KEY"]
+        alias: APP_KEY
+```
+
+### Local Azure Key Vault loading
+
+When `chartPath` is set and `NODE_ENV !== "production"`, the chart's `keyVaults` block is read and secrets are fetched directly from Azure using `DefaultAzureCredential`. The default vault URI is `https://<vault-name>-aat.vault.azure.net/`; override with `vaultUriSuffix`:
+
+```typescript
+await getPropertiesVolumeSecrets({
+  chartPath: "./charts/my-service/values.yaml",
+  vaultUriSuffix: "stg"   // default "aat"
+});
+```
+
+### Options
+
+| Option | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `mountPoint` | `string` | `/mnt/secrets` | Filesystem path to look for CSI-mounted secrets. |
+| `chartPath` | `string` | — | Helm values file. Enables local Azure Vault loading (non-prod) and alias mapping (prod). |
+| `injectEnvVars` | `boolean` | `true` | Write each secret to `process.env` as well as returning it. |
+| `omit` | `string[]` | `[]` | Secret keys to skip (matched by full key or last `.`-segment). |
+| `failOnError` | `boolean` | `NODE_ENV==="production"` | Throw on missing mount / failed reads instead of logging a warning. |
+| `vaultUriSuffix` | `string` | `"aat"` | Suffix for the Azure Key Vault URI when loading locally. |
+
+### `addFromAzureVault`
+
+Lower-level: populate a `config`-shaped object directly from a Helm chart's vault definitions. Used internally by `getPropertiesVolumeSecrets` but also exposed for callers that want to feed the `config` package:
+
+```typescript
+import config from "config";
+import { addFromAzureVault } from "@hmcts-cft/cloud-native-platform";
+
+await addFromAzureVault(config, {
+  pathToHelmChart: "./charts/my-service/values.yaml",
+  vaultUriSuffix: "stg"
+});
+```

--- a/libs/cloud-native-platform/package.json
+++ b/libs/cloud-native-platform/package.json
@@ -1,13 +1,28 @@
 {
-  "name": "@hmcts/cloud-native-platform",
+  "name": "@hmcts-cft/cloud-native-platform",
   "version": "1.0.0",
-  "private": true,
+  "description": "HMCTS cloud-native-platform helpers for Express: health checks, Application Insights monitoring middleware, exception tracking, and properties-volume / Azure Key Vault secret loading.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hmcts/expressjs-monorepo-template.git",
+    "directory": "libs/cloud-native-platform"
+  },
+  "homepage": "https://github.com/hmcts/expressjs-monorepo-template/tree/master/libs/cloud-native-platform#readme",
+  "bugs": "https://github.com/hmcts/expressjs-monorepo-template/issues",
   "type": "module",
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }
+  },
+  "publishConfig": {
+    "registry": "https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/npm/registry/"
   },
   "scripts": {
     "build": "tsc",

--- a/libs/cloud-native-platform/src/healthcheck/healthcheck.test.ts
+++ b/libs/cloud-native-platform/src/healthcheck/healthcheck.test.ts
@@ -76,16 +76,6 @@ describe("healthcheck", () => {
       expect(await check()).toBe("DOWN");
     });
 
-    it("should return UP when check returns void", async () => {
-      const check = raw(() => {});
-      expect(await check()).toBe("UP");
-    });
-
-    it("should return UP for async void", async () => {
-      const check = raw(async () => {});
-      expect(await check()).toBe("UP");
-    });
-
     it("should return DOWN on error", async () => {
       const check = raw(() => {
         throw new Error("Check failed");

--- a/libs/cloud-native-platform/src/healthcheck/healthcheck.test.ts
+++ b/libs/cloud-native-platform/src/healthcheck/healthcheck.test.ts
@@ -76,6 +76,16 @@ describe("healthcheck", () => {
       expect(await check()).toBe("DOWN");
     });
 
+    it("should return UP when check returns void", async () => {
+      const check = raw(() => {});
+      expect(await check()).toBe("UP");
+    });
+
+    it("should return UP for async void", async () => {
+      const check = raw(async () => {});
+      expect(await check()).toBe("UP");
+    });
+
     it("should return DOWN on error", async () => {
       const check = raw(() => {
         throw new Error("Check failed");

--- a/libs/cloud-native-platform/src/healthcheck/healthcheck.ts
+++ b/libs/cloud-native-platform/src/healthcheck/healthcheck.ts
@@ -28,10 +28,11 @@ export function web(url: string, timeout = 10000): HealthCheck {
   };
 }
 
-export function raw(check: () => Promise<HealthStatus> | HealthStatus): HealthCheck {
+export function raw(check: () => Promise<unknown> | unknown): HealthCheck {
   return async () => {
     try {
-      return await check();
+      const result = await check();
+      return result === "UP" || result === "DOWN" ? result : "UP";
     } catch {
       return "DOWN";
     }

--- a/libs/cloud-native-platform/src/healthcheck/healthcheck.ts
+++ b/libs/cloud-native-platform/src/healthcheck/healthcheck.ts
@@ -28,12 +28,10 @@ export function web(url: string, timeout = 10000): HealthCheck {
   };
 }
 
-export function raw(check: () => Promise<HealthStatus | unknown> | HealthStatus | unknown): HealthCheck {
+export function raw(check: () => Promise<HealthStatus> | HealthStatus): HealthCheck {
   return async () => {
     try {
-      const result = await check();
-
-      return result === "UP" || result === "DOWN" ? result : "UP";
+      return await check();
     } catch {
       return "DOWN";
     }

--- a/libs/cloud-native-platform/src/index.ts
+++ b/libs/cloud-native-platform/src/index.ts
@@ -4,6 +4,7 @@ import { configure } from "./healthcheck/healthcheck-middleware.js";
 export * from "./healthcheck/healthcheck.js";
 export * from "./monitoring/monitoring-middleware.js";
 export * from "./monitoring/monitoring-service.js";
+export * from "./monitoring/track-exception.js";
 export { addFromAzureVault } from "./properties-volume/azure-vault.js";
 export type { GetSecretsOptions, Secrets } from "./properties-volume/properties.js";
 export { getPropertiesVolumeSecrets } from "./properties-volume/properties.js";

--- a/libs/cloud-native-platform/src/monitoring/track-exception.test.ts
+++ b/libs/cloud-native-platform/src/monitoring/track-exception.test.ts
@@ -1,0 +1,213 @@
+import * as appInsights from "applicationinsights";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { trackException } from "./track-exception.js";
+
+vi.mock("applicationinsights", () => {
+  const mockClient = {
+    trackException: vi.fn()
+  };
+
+  return {
+    defaultClient: mockClient
+  };
+});
+
+describe("trackException", () => {
+  let consoleErrorSpy: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  describe("when Application Insights is initialized", () => {
+    it("should track exception and log error message", () => {
+      const error = new Error("Test error");
+
+      trackException(error);
+
+      expect(console.error).toHaveBeenCalledWith("Test error", {
+        error
+      });
+
+      expect(appInsights.defaultClient.trackException).toHaveBeenCalledWith({
+        exception: error,
+        properties: undefined
+      });
+    });
+
+    it("should track exception with properties", () => {
+      const error = new Error("Database connection failed");
+      const properties = {
+        userId: "user-123",
+        area: "database",
+        operation: "connect"
+      };
+
+      trackException(error, properties);
+
+      expect(console.error).toHaveBeenCalledWith("Database connection failed", {
+        error,
+        userId: "user-123",
+        area: "database",
+        operation: "connect"
+      });
+
+      expect(appInsights.defaultClient.trackException).toHaveBeenCalledWith({
+        exception: error,
+        properties
+      });
+    });
+
+    it("should track exception with empty properties object", () => {
+      const error = new Error("Empty properties test");
+      const properties = {};
+
+      trackException(error, properties);
+
+      expect(console.error).toHaveBeenCalledWith("Empty properties test", {
+        error
+      });
+
+      expect(appInsights.defaultClient.trackException).toHaveBeenCalledWith({
+        exception: error,
+        properties
+      });
+    });
+
+    it("should handle error with special characters in message", () => {
+      const error = new Error("Error with 'quotes' and \"double quotes\"");
+
+      trackException(error);
+
+      expect(console.error).toHaveBeenCalledWith("Error with 'quotes' and \"double quotes\"", {
+        error
+      });
+
+      expect(appInsights.defaultClient.trackException).toHaveBeenCalled();
+    });
+
+    it("should handle error with multiline message", () => {
+      const error = new Error("Line 1\nLine 2\nLine 3");
+
+      trackException(error);
+
+      expect(console.error).toHaveBeenCalledWith("Line 1\nLine 2\nLine 3", {
+        error
+      });
+
+      expect(appInsights.defaultClient.trackException).toHaveBeenCalled();
+    });
+  });
+
+  describe("when Application Insights is not initialized", () => {
+    beforeEach(() => {
+      // Mock defaultClient as null to simulate AI not being initialized
+      vi.mocked(appInsights).defaultClient = null as any;
+    });
+
+    afterEach(() => {
+      // Restore mock client for other tests
+      vi.mocked(appInsights).defaultClient = {
+        trackException: vi.fn()
+      } as any;
+    });
+
+    it("should log error message when defaultClient is null", () => {
+      const error = new Error("Test error without AI");
+
+      trackException(error);
+
+      expect(console.error).toHaveBeenCalledWith("Application Insights not initialized, cannot track exception:", "Test error without AI", undefined);
+
+      // trackException should not be called when defaultClient is null
+      expect(appInsights.defaultClient).toBeNull();
+    });
+
+    it("should log error with properties when defaultClient is null", () => {
+      const error = new Error("Another error");
+      const properties = {
+        userId: "user-456",
+        context: "testing"
+      };
+
+      trackException(error, properties);
+
+      expect(console.error).toHaveBeenCalledWith("Application Insights not initialized, cannot track exception:", "Another error", properties);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle Error with empty message", () => {
+      const error = new Error("");
+
+      trackException(error);
+
+      expect(console.error).toHaveBeenCalledWith("", {
+        error
+      });
+
+      expect(appInsights.defaultClient.trackException).toHaveBeenCalledWith({
+        exception: error,
+        properties: undefined
+      });
+    });
+
+    it("should handle properties with nested objects", () => {
+      const error = new Error("Nested properties test");
+      const properties = {
+        user: {
+          id: "user-123",
+          name: "Test User"
+        },
+        metadata: {
+          timestamp: new Date().toISOString(),
+          version: "1.0.0"
+        }
+      };
+
+      trackException(error, properties);
+
+      expect(console.error).toHaveBeenCalledWith("Nested properties test", {
+        error,
+        user: {
+          id: "user-123",
+          name: "Test User"
+        },
+        metadata: {
+          timestamp: expect.any(String),
+          version: "1.0.0"
+        }
+      });
+
+      expect(appInsights.defaultClient.trackException).toHaveBeenCalledWith({
+        exception: error,
+        properties
+      });
+    });
+
+    it("should handle properties with null values", () => {
+      const error = new Error("Null properties test");
+      const properties = {
+        userId: "user-789",
+        optionalField: null,
+        anotherField: undefined
+      };
+
+      trackException(error, properties);
+
+      expect(console.error).toHaveBeenCalledWith("Null properties test", {
+        error,
+        userId: "user-789",
+        optionalField: null,
+        anotherField: undefined
+      });
+
+      expect(appInsights.defaultClient.trackException).toHaveBeenCalled();
+    });
+  });
+});

--- a/libs/cloud-native-platform/src/monitoring/track-exception.test.ts
+++ b/libs/cloud-native-platform/src/monitoring/track-exception.test.ts
@@ -13,7 +13,7 @@ vi.mock("applicationinsights", () => {
 });
 
 describe("trackException", () => {
-  let consoleErrorSpy: any;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/libs/cloud-native-platform/src/monitoring/track-exception.ts
+++ b/libs/cloud-native-platform/src/monitoring/track-exception.ts
@@ -1,0 +1,22 @@
+import * as appInsights from "applicationinsights";
+
+/**
+ * Tracks an exception to Application Insights using the default client.
+ * This function should be used in route handlers where the MonitoringService instance is not directly available.
+ * Requires that Application Insights has been initialized via monitoringMiddleware.
+ *
+ * @param error - The error to track
+ * @param properties - Optional contextual properties to include with the exception
+ */
+export function trackException(error: Error, properties?: Record<string, any>): void {
+  if (appInsights.defaultClient) {
+    console.error(error.message, { error, ...properties });
+
+    appInsights.defaultClient.trackException({
+      exception: error,
+      properties
+    });
+  } else {
+    console.error("Application Insights not initialized, cannot track exception:", error.message, properties);
+  }
+}

--- a/libs/cloud-native-platform/src/monitoring/track-exception.ts
+++ b/libs/cloud-native-platform/src/monitoring/track-exception.ts
@@ -8,9 +8,9 @@ import * as appInsights from "applicationinsights";
  * @param error - The error to track
  * @param properties - Optional contextual properties to include with the exception
  */
-export function trackException(error: Error, properties?: Record<string, any>): void {
+export function trackException(error: Error, properties?: Record<string, unknown>): void {
   if (appInsights.defaultClient) {
-    console.error(error.message, { error, ...properties });
+    console.error(error.message, { ...properties, error });
 
     appInsights.defaultClient.trackException({
       exception: error,

--- a/libs/cloud-native-platform/src/properties-volume/azure-vault.test.ts
+++ b/libs/cloud-native-platform/src/properties-volume/azure-vault.test.ts
@@ -81,6 +81,24 @@ describe("addFromAzureVault", () => {
     });
   });
 
+  it("should use custom vault URI suffix when provided", async () => {
+    const helmChart = {
+      keyVaults: {
+        "my-app": {
+          secrets: ["secret1"]
+        }
+      }
+    };
+
+    mockReadFileSync.mockReturnValue("helm-chart-content");
+    mockYamlLoad.mockReturnValue(helmChart);
+    mockClient.getSecret.mockResolvedValueOnce({ value: "secret-value" });
+
+    await addFromAzureVault(config, { pathToHelmChart: "/path/to/chart.yaml", vaultUriSuffix: "stg" });
+
+    expect(mockSecretClient).toHaveBeenCalledWith("https://my-app-stg.vault.azure.net/", expect.any(Object));
+  });
+
   it("should handle multiple vaults", async () => {
     const helmChart = {
       keyVaults: {

--- a/libs/cloud-native-platform/src/properties-volume/azure-vault.test.ts
+++ b/libs/cloud-native-platform/src/properties-volume/azure-vault.test.ts
@@ -153,7 +153,7 @@ describe("addFromAzureVault", () => {
 
     await addFromAzureVault(config, { pathToHelmChart: "/path/to/chart.yaml" });
 
-    expect(consoleWarnSpy).toHaveBeenCalledWith("Azure Vault: Invalid vault configuration, missing name or secrets");
+    expect(consoleWarnSpy).toHaveBeenCalledWith("Azure Vault: Invalid vault configuration for 'incomplete-vault', missing secrets");
     expect(config).toEqual({
       existing: "value",
       secret1: "value1"
@@ -316,7 +316,7 @@ describe("addFromAzureVault", () => {
 
     await addFromAzureVault(config, { pathToHelmChart: "/path/to/chart.yaml" });
 
-    expect(consoleWarnSpy).toHaveBeenCalledWith("Azure Vault: Invalid vault configuration, missing name or secrets");
+    expect(consoleWarnSpy).toHaveBeenCalledWith("Azure Vault: Invalid vault configuration for 'vault-name', missing secrets");
     expect(config).toEqual({ existing: "value" });
   });
 

--- a/libs/cloud-native-platform/src/properties-volume/azure-vault.ts
+++ b/libs/cloud-native-platform/src/properties-volume/azure-vault.ts
@@ -26,15 +26,15 @@ export async function addFromAzureVault(config: Config, options: AzureVaultOptio
       return;
     }
 
-    for (const _ of invalidVaultNames) {
-      console.warn("Azure Vault: Invalid vault configuration, missing name or secrets");
+    for (const vaultName of invalidVaultNames) {
+      console.warn(`Azure Vault: Invalid vault configuration for '${vaultName}', missing secrets`);
     }
 
     for (const vault of vaults) {
       await processVault(config, vault, vaultUriSuffix);
     }
-  } catch (error: any) {
-    throw new Error(`Azure Key Vault: ${error.message || error}`);
+  } catch (error: unknown) {
+    throw new Error(`Azure Key Vault: ${errorMessage(error)}`);
   }
 }
 
@@ -49,9 +49,10 @@ async function processVault(config: Config, vault: VaultDefinition, vaultUriSuff
     const secretResults = await Promise.all(secrets.map((secret) => processSecret(client, secret)));
     const secretsConfig: Config = Object.fromEntries(secretResults.map(({ key, value }) => [key, value]));
     Object.assign(config, deepMerge(config, secretsConfig));
-  } catch (error: any) {
-    if (error.message && !error.message.includes(vaultName)) {
-      throw new Error(`Vault '${vaultName}': ${error.message}`);
+  } catch (error: unknown) {
+    const message = errorMessage(error);
+    if (message && !message.includes(vaultName)) {
+      throw new Error(`Vault '${vaultName}': ${message}`);
     }
     throw error;
   }
@@ -67,10 +68,21 @@ async function processSecret(client: SecretClient, secret: SecretDefinition): Pr
       throw new Error(`Secret ${secretName} has no value`);
     }
     return { key: configKey, value: secretResponse.value };
-  } catch (error: any) {
-    if (error?.statusCode === 403 || error?.message?.includes("does not have secrets get permission")) {
+  } catch (error: unknown) {
+    if (isPermissionDenied(error)) {
       throw new Error(`Could not load secret '${secretName}'. Check it exists and you have access to it.`);
     }
-    throw new Error(`Failed to retrieve secret ${secretName}: ${error.message || error}`);
+    throw new Error(`Failed to retrieve secret ${secretName}: ${errorMessage(error)}`);
   }
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
+function isPermissionDenied(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const e = error as { statusCode?: number; message?: string };
+  return e.statusCode === 403 || (typeof e.message === "string" && e.message.includes("does not have secrets get permission"));
 }

--- a/libs/cloud-native-platform/src/properties-volume/azure-vault.ts
+++ b/libs/cloud-native-platform/src/properties-volume/azure-vault.ts
@@ -1,9 +1,8 @@
-import { readFileSync } from "node:fs";
 import { DefaultAzureCredential } from "@azure/identity";
 import { SecretClient } from "@azure/keyvault-secrets";
-import { load as yamlLoad } from "js-yaml";
+import { parseVaultsFromHelmChart, type SecretDefinition, type VaultDefinition } from "./helm-chart.js";
 import type { Config } from "./properties.js";
-import { deepMerge, deepSearch, normalizeSecretName } from "./utils.js";
+import { deepMerge, normalizeSecretName } from "./utils.js";
 
 export interface AzureVaultOptions {
   pathToHelmChart: string;
@@ -11,13 +10,6 @@ export interface AzureVaultOptions {
 }
 
 const DEFAULT_VAULT_URI_SUFFIX = "aat";
-
-export interface StructuredSecret {
-  alias: string;
-  name: string;
-}
-
-export type StructuredOrUnstructuredSecret = string | StructuredSecret;
 
 /**
  * Adds secrets from Azure Key Vault to configuration object
@@ -27,66 +19,37 @@ export async function addFromAzureVault(config: Config, options: AzureVaultOptio
   const { pathToHelmChart, vaultUriSuffix = DEFAULT_VAULT_URI_SUFFIX } = options;
 
   try {
-    // Load and parse Helm chart YAML
-    const helmChartContent = readFileSync(pathToHelmChart, "utf8");
-    const helmChart = yamlLoad(helmChartContent) as any;
+    const { vaults, hasKeyVaultsKey, invalidVaultNames } = parseVaultsFromHelmChart(pathToHelmChart);
 
-    // Find all keyVaults in the Helm chart
-    const keyVaults = deepSearch(helmChart, "keyVaults");
-
-    if (!keyVaults.length) {
+    if (!hasKeyVaultsKey) {
       console.warn("Azure Vault: No keyVaults found in Helm chart");
       return;
     }
 
-    // Process each keyVaults object found
-    for (const keyVaultsObj of keyVaults) {
-      if (keyVaultsObj && typeof keyVaultsObj === "object") {
-        // keyVaultsObj should be an object with vault names as keys
-        for (const [vaultName, vaultConfig] of Object.entries(keyVaultsObj)) {
-          const vault = { name: vaultName };
-          if (vaultConfig && typeof vaultConfig === "object") {
-            Object.assign(vault, vaultConfig);
-          }
-          await processVault(config, vault, vaultUriSuffix);
-        }
-      }
+    for (const _ of invalidVaultNames) {
+      console.warn("Azure Vault: Invalid vault configuration, missing name or secrets");
+    }
+
+    for (const vault of vaults) {
+      await processVault(config, vault, vaultUriSuffix);
     }
   } catch (error: any) {
-    // Provide cleaner error message
-    const message = error.message || error;
-    throw new Error(`Azure Key Vault: ${message}`);
+    throw new Error(`Azure Key Vault: ${error.message || error}`);
   }
 }
 
-/**
- * Process a single vault configuration
- */
-async function processVault(config: Config, vault: any, vaultUriSuffix: string): Promise<void> {
+async function processVault(config: Config, vault: VaultDefinition, vaultUriSuffix: string): Promise<void> {
   const { name: vaultName, secrets } = vault;
-
-  if (!vaultName || !secrets) {
-    console.warn("Azure Vault: Invalid vault configuration, missing name or secrets");
-    return;
-  }
 
   const vaultUri = `https://${vaultName}-${vaultUriSuffix}.vault.azure.net/`;
   const credential = new DefaultAzureCredential();
   const client = new SecretClient(vaultUri, credential);
-  const secretPromises = secrets.map((secret: StructuredOrUnstructuredSecret) => processSecret(client, secret));
 
   try {
-    const secretResults = await Promise.all(secretPromises);
-
-    // Merge all secrets into config
-    const secretsConfig: Config = {};
-    for (const { key, value } of secretResults) {
-      secretsConfig[key] = value;
-    }
-
+    const secretResults = await Promise.all(secrets.map((secret) => processSecret(client, secret)));
+    const secretsConfig: Config = Object.fromEntries(secretResults.map(({ key, value }) => [key, value]));
     Object.assign(config, deepMerge(config, secretsConfig));
   } catch (error: any) {
-    // Re-throw with vault context if not already included
     if (error.message && !error.message.includes(vaultName)) {
       throw new Error(`Vault '${vaultName}': ${error.message}`);
     }
@@ -94,34 +57,17 @@ async function processVault(config: Config, vault: any, vaultUriSuffix: string):
   }
 }
 
-/**
- * Process a single secret from the vault
- */
-async function processSecret(client: SecretClient, secret: StructuredOrUnstructuredSecret): Promise<{ key: string; value: string }> {
-  let secretName: string;
-  let configKey: string;
-
-  if (typeof secret === "string") {
-    secretName = secret;
-    configKey = normalizeSecretName(secret);
-  } else {
-    secretName = secret.name;
-    configKey = secret.alias || normalizeSecretName(secret.name);
-  }
+async function processSecret(client: SecretClient, secret: SecretDefinition): Promise<{ key: string; value: string }> {
+  const { name: secretName } = secret;
+  const configKey = secret.alias ?? normalizeSecretName(secretName);
 
   try {
     const secretResponse = await client.getSecret(secretName);
-
     if (!secretResponse.value) {
       throw new Error(`Secret ${secretName} has no value`);
     }
-
-    return {
-      key: configKey,
-      value: secretResponse.value
-    };
+    return { key: configKey, value: secretResponse.value };
   } catch (error: any) {
-    // Extract cleaner error message for common Azure Key Vault permission issues
     if (error?.statusCode === 403 || error?.message?.includes("does not have secrets get permission")) {
       throw new Error(`Could not load secret '${secretName}'. Check it exists and you have access to it.`);
     }

--- a/libs/cloud-native-platform/src/properties-volume/azure-vault.ts
+++ b/libs/cloud-native-platform/src/properties-volume/azure-vault.ts
@@ -7,7 +7,10 @@ import { deepMerge, deepSearch, normalizeSecretName } from "./utils.js";
 
 export interface AzureVaultOptions {
   pathToHelmChart: string;
+  vaultUriSuffix?: string;
 }
+
+const DEFAULT_VAULT_URI_SUFFIX = "aat";
 
 export interface StructuredSecret {
   alias: string;
@@ -21,7 +24,7 @@ export type StructuredOrUnstructuredSecret = string | StructuredSecret;
  * Matches the API of @hmcts/properties-volume addFromAzureVault function
  */
 export async function addFromAzureVault(config: Config, options: AzureVaultOptions): Promise<void> {
-  const { pathToHelmChart } = options;
+  const { pathToHelmChart, vaultUriSuffix = DEFAULT_VAULT_URI_SUFFIX } = options;
 
   try {
     // Load and parse Helm chart YAML
@@ -45,7 +48,7 @@ export async function addFromAzureVault(config: Config, options: AzureVaultOptio
           if (vaultConfig && typeof vaultConfig === "object") {
             Object.assign(vault, vaultConfig);
           }
-          await processVault(config, vault);
+          await processVault(config, vault, vaultUriSuffix);
         }
       }
     }
@@ -59,7 +62,7 @@ export async function addFromAzureVault(config: Config, options: AzureVaultOptio
 /**
  * Process a single vault configuration
  */
-async function processVault(config: Config, vault: any): Promise<void> {
+async function processVault(config: Config, vault: any, vaultUriSuffix: string): Promise<void> {
   const { name: vaultName, secrets } = vault;
 
   if (!vaultName || !secrets) {
@@ -67,7 +70,7 @@ async function processVault(config: Config, vault: any): Promise<void> {
     return;
   }
 
-  const vaultUri = `https://${vaultName}-aat.vault.azure.net/`;
+  const vaultUri = `https://${vaultName}-${vaultUriSuffix}.vault.azure.net/`;
   const credential = new DefaultAzureCredential();
   const client = new SecretClient(vaultUri, credential);
   const secretPromises = secrets.map((secret: StructuredOrUnstructuredSecret) => processSecret(client, secret));

--- a/libs/cloud-native-platform/src/properties-volume/helm-chart.ts
+++ b/libs/cloud-native-platform/src/properties-volume/helm-chart.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from "node:fs";
+import { load as yamlLoad } from "js-yaml";
+import { deepSearch } from "./utils.js";
+
+export interface VaultDefinition {
+  name: string;
+  secrets: SecretDefinition[];
+}
+
+export interface SecretDefinition {
+  name: string;
+  alias?: string;
+}
+
+export interface ParsedHelmChart {
+  vaults: VaultDefinition[];
+  hasKeyVaultsKey: boolean;
+  invalidVaultNames: string[];
+}
+
+export function parseVaultsFromHelmChart(chartPath: string): ParsedHelmChart {
+  const chart = yamlLoad(readFileSync(chartPath, "utf8"));
+  const keyVaultsEntries = deepSearch(chart, "keyVaults");
+
+  const vaults: VaultDefinition[] = [];
+  const invalidVaultNames: string[] = [];
+
+  for (const entry of keyVaultsEntries) {
+    if (!isRecord(entry)) continue;
+    for (const [name, config] of Object.entries(entry)) {
+      const secrets = parseSecrets(config);
+      if (secrets) {
+        vaults.push({ name, secrets });
+      } else {
+        invalidVaultNames.push(name);
+      }
+    }
+  }
+
+  return { vaults, hasKeyVaultsKey: keyVaultsEntries.length > 0, invalidVaultNames };
+}
+
+function parseSecrets(vaultConfig: unknown): SecretDefinition[] | null {
+  if (!isRecord(vaultConfig) || !Array.isArray(vaultConfig.secrets)) return null;
+  return vaultConfig.secrets.map(parseSecret).filter((s): s is SecretDefinition => s !== null);
+}
+
+function parseSecret(secret: unknown): SecretDefinition | null {
+  if (typeof secret === "string") return { name: secret };
+  if (!isRecord(secret) || typeof secret.name !== "string") return null;
+  return typeof secret.alias === "string" ? { name: secret.name, alias: secret.alias } : { name: secret.name };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/libs/cloud-native-platform/src/properties-volume/helm-chart.ts
+++ b/libs/cloud-native-platform/src/properties-volume/helm-chart.ts
@@ -2,22 +2,6 @@ import { readFileSync } from "node:fs";
 import { load as yamlLoad } from "js-yaml";
 import { deepSearch } from "./utils.js";
 
-export interface VaultDefinition {
-  name: string;
-  secrets: SecretDefinition[];
-}
-
-export interface SecretDefinition {
-  name: string;
-  alias?: string;
-}
-
-export interface ParsedHelmChart {
-  vaults: VaultDefinition[];
-  hasKeyVaultsKey: boolean;
-  invalidVaultNames: string[];
-}
-
 export function parseVaultsFromHelmChart(chartPath: string): ParsedHelmChart {
   const chart = yamlLoad(readFileSync(chartPath, "utf8"));
   const keyVaultsEntries = deepSearch(chart, "keyVaults");
@@ -53,4 +37,20 @@ function parseSecret(secret: unknown): SecretDefinition | null {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export interface VaultDefinition {
+  name: string;
+  secrets: SecretDefinition[];
+}
+
+export interface SecretDefinition {
+  name: string;
+  alias?: string;
+}
+
+export interface ParsedHelmChart {
+  vaults: VaultDefinition[];
+  hasKeyVaultsKey: boolean;
+  invalidVaultNames: string[];
 }

--- a/libs/cloud-native-platform/src/properties-volume/properties.test.ts
+++ b/libs/cloud-native-platform/src/properties-volume/properties.test.ts
@@ -1,5 +1,6 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { addFromAzureVault } from "./azure-vault.js";
 import { getPropertiesVolumeSecrets } from "./properties.js";
 
 vi.mock("node:fs", () => ({
@@ -15,486 +16,477 @@ vi.mock("./azure-vault.js", () => ({
 const mockExistsSync = vi.mocked(existsSync);
 const mockReaddirSync = vi.mocked(readdirSync);
 const mockReadFileSync = vi.mocked(readFileSync);
-
-// Import after mocking
-const { addFromAzureVault } = await import("./azure-vault.js");
 const mockAddFromAzureVault = vi.mocked(addFromAzureVault);
 
+function dirEntry(name: string, isDir: boolean, isSymlink = false) {
+  return { name, isDirectory: () => isDir, isFile: () => !isDir && !isSymlink, isSymbolicLink: () => isSymlink } as any;
+}
+
+function fileEntry(name: string, isSymlink = false) {
+  return dirEntry(name, false, isSymlink);
+}
+
 describe("getPropertiesVolumeSecrets", () => {
-  let consoleWarnSpy: any;
-  let originalProcessEnv: NodeJS.ProcessEnv;
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+  const originalEnv = { ...process.env };
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockExistsSync.mockClear();
-    mockReaddirSync.mockClear();
-    mockReadFileSync.mockClear();
-    mockAddFromAzureVault.mockClear();
-    originalProcessEnv = { ...process.env };
     consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    process.env = { ...originalEnv };
   });
 
   afterEach(() => {
     consoleWarnSpy.mockRestore();
-    process.env = originalProcessEnv;
+    process.env = originalEnv;
   });
 
-  it("should read secrets from vault subdirectories with prefixed keys", async () => {
+  it("should read vault subdirectories with prefixed keys", async () => {
+    // Arrange
+    mockExistsSync.mockReturnValue(false); // no chartPath match
+    mockExistsSync.mockReturnValue(true); // mount point exists
+    mockReaddirSync.mockReturnValueOnce([dirEntry("pip-ss-kv", true)] as any);
+    mockReaddirSync.mockReturnValueOnce([fileEntry("DATABASE_URL"), fileEntry("APP_SECRET")] as any);
+    mockReadFileSync.mockReturnValueOnce("db-connection-string" as any).mockReturnValueOnce("my-secret" as any);
+
+    // Act
+    const secrets = await getPropertiesVolumeSecrets();
+
+    // Assert
+    expect(secrets["pip-ss-kv.DATABASE_URL"]).toBe("db-connection-string");
+    expect(secrets["pip-ss-kv.APP_SECRET"]).toBe("my-secret");
+  });
+
+  it("should inject env vars when injectEnvVars is true (default)", async () => {
+    // Arrange
     mockExistsSync.mockReturnValue(true);
-    mockReaddirSync.mockReturnValueOnce([{ name: "dtsse", isDirectory: () => true, isFile: () => false }] as any);
-    mockReaddirSync.mockReturnValueOnce([
-      { name: "DATABASE_URL", isFile: () => true },
-      { name: "APPLICATION_INSIGHTS_CONNECTION_STRING", isFile: () => true }
-    ] as any);
-    mockReadFileSync.mockReturnValueOnce("postgresql://localhost:5432/db").mockReturnValueOnce("InstrumentationKey=abc123");
+    mockReaddirSync.mockReturnValueOnce([dirEntry("vault", true)] as any);
+    mockReaddirSync.mockReturnValueOnce([fileEntry("MY_SECRET")] as any);
+    mockReadFileSync.mockReturnValue("secret-value" as any);
 
-    const secrets = await getPropertiesVolumeSecrets({ injectEnvVars: false });
+    // Act
+    await getPropertiesVolumeSecrets();
 
-    expect(secrets).toEqual({
-      "dtsse.DATABASE_URL": "postgresql://localhost:5432/db",
-      "dtsse.APPLICATION_INSIGHTS_CONNECTION_STRING": "InstrumentationKey=abc123"
-    });
+    // Assert
+    expect(process.env.MY_SECRET).toBe("secret-value");
   });
 
-  it("should inject secrets into process.env when injectEnvVars is true", async () => {
+  it("should not inject env vars when injectEnvVars is false", async () => {
+    // Arrange
+    delete process.env.NO_INJECT_SECRET;
     mockExistsSync.mockReturnValue(true);
-    mockReaddirSync.mockReturnValueOnce([{ name: "dtsse", isDirectory: () => true, isFile: () => false }] as any);
-    mockReaddirSync.mockReturnValueOnce([
-      { name: "DATABASE_URL", isFile: () => true },
-      { name: "API_KEY", isFile: () => true }
-    ] as any);
-    mockReadFileSync.mockReturnValueOnce("postgresql://localhost:5432/db").mockReturnValueOnce("secret-key");
+    mockReaddirSync.mockReturnValueOnce([dirEntry("vault", true)] as any);
+    mockReaddirSync.mockReturnValueOnce([fileEntry("NO_INJECT_SECRET")] as any);
+    mockReadFileSync.mockReturnValue("secret-value" as any);
 
-    const secrets = await getPropertiesVolumeSecrets({ injectEnvVars: true });
+    // Act
+    await getPropertiesVolumeSecrets({ injectEnvVars: false });
 
-    expect(secrets).toEqual({
-      "dtsse.DATABASE_URL": "postgresql://localhost:5432/db",
-      "dtsse.API_KEY": "secret-key"
-    });
-    expect(process.env.DATABASE_URL).toBe("postgresql://localhost:5432/db");
-    expect(process.env.API_KEY).toBe("secret-key");
+    // Assert
+    expect(process.env.NO_INJECT_SECRET).toBeUndefined();
   });
 
-  it("should not inject into process.env when injectEnvVars is false", async () => {
+  it("should read direct files without subdirectories", async () => {
+    // Arrange
     mockExistsSync.mockReturnValue(true);
-    mockReaddirSync.mockReturnValueOnce([{ name: "dtsse", isDirectory: () => true, isFile: () => false }] as any);
-    mockReaddirSync.mockReturnValueOnce([{ name: "SECRET_KEY", isFile: () => true }] as any);
-    mockReadFileSync.mockReturnValueOnce("my-secret");
+    mockReaddirSync.mockReturnValueOnce([fileEntry("secret1"), fileEntry("secret2")] as any);
+    mockReadFileSync.mockReturnValueOnce("value1" as any).mockReturnValueOnce("value2" as any);
 
-    delete process.env.SECRET_KEY;
-    const secrets = await getPropertiesVolumeSecrets({ injectEnvVars: false });
+    // Act
+    const secrets = await getPropertiesVolumeSecrets();
 
-    expect(secrets).toEqual({
-      "dtsse.SECRET_KEY": "my-secret"
-    });
-    expect(process.env.SECRET_KEY).toBeUndefined();
+    // Assert
+    expect(secrets.secret1).toBe("value1");
+    expect(secrets.secret2).toBe("value2");
   });
 
-  it("should handle direct files without vault subdirectories", async () => {
+  it("should handle mixed vault dirs and direct files", async () => {
+    // Arrange
     mockExistsSync.mockReturnValue(true);
-    mockReaddirSync.mockReturnValueOnce([{ name: "direct-secret", isDirectory: () => false, isFile: () => true }] as any);
-    mockReadFileSync.mockReturnValueOnce("direct-value");
+    mockReaddirSync.mockReturnValueOnce([dirEntry("my-vault", true), fileEntry("direct-file")] as any);
+    mockReaddirSync.mockReturnValueOnce([fileEntry("VAULT_SECRET")] as any);
+    mockReadFileSync.mockReturnValueOnce("vault-value" as any).mockReturnValueOnce("direct-value" as any);
 
-    const secrets = await getPropertiesVolumeSecrets({ injectEnvVars: false });
+    // Act
+    const secrets = await getPropertiesVolumeSecrets();
 
-    expect(secrets).toEqual({
-      "direct-secret": "direct-value"
-    });
+    // Assert
+    expect(secrets["my-vault.VAULT_SECRET"]).toBe("vault-value");
+    expect(secrets["direct-file"]).toBe("direct-value");
   });
 
-  it("should handle mixed vault directories and direct files", async () => {
+  it("should skip entries starting with '..' inside vault directories", async () => {
+    // Arrange
     mockExistsSync.mockReturnValue(true);
-    mockReaddirSync.mockReturnValueOnce([
-      { name: "vault1", isDirectory: () => true, isFile: () => false },
-      { name: "direct-file", isDirectory: () => false, isFile: () => true }
-    ] as any);
-    mockReaddirSync.mockReturnValueOnce([{ name: "secret1", isFile: () => true }] as any);
-    mockReadFileSync.mockReturnValueOnce("vault-value").mockReturnValueOnce("direct-value");
+    mockReaddirSync.mockReturnValueOnce([dirEntry("vault", true)] as any);
+    mockReaddirSync.mockReturnValueOnce([fileEntry("..hidden"), fileEntry("VISIBLE_SECRET")] as any);
+    mockReadFileSync.mockReturnValue("value" as any);
 
-    const secrets = await getPropertiesVolumeSecrets({ injectEnvVars: false });
+    // Act
+    const secrets = await getPropertiesVolumeSecrets();
 
-    expect(secrets).toEqual({
-      "vault1.secret1": "vault-value",
-      "direct-file": "direct-value"
-    });
-  });
-
-  it("should return empty object when mount point does not exist", async () => {
-    mockExistsSync.mockReturnValue(false);
-
-    const secrets = await getPropertiesVolumeSecrets({ failOnError: false });
-
-    expect(secrets).toEqual({});
-    expect(consoleWarnSpy).toHaveBeenCalledWith("Warning: Mount point /mnt/secrets does not exist");
+    // Assert
+    expect(secrets["vault...hidden"]).toBeUndefined();
+    expect(secrets["vault.VISIBLE_SECRET"]).toBe("value");
   });
 
   it("should throw error when mount point does not exist and failOnError is true", async () => {
+    // Arrange
     mockExistsSync.mockReturnValue(false);
 
+    // Act & Assert
     await expect(getPropertiesVolumeSecrets({ failOnError: true })).rejects.toThrow("Mount point /mnt/secrets does not exist");
   });
 
-  it("should handle file read errors when failOnError is false", async () => {
-    mockExistsSync.mockReturnValue(true);
-    mockReaddirSync.mockReturnValueOnce([{ name: "dtsse", isDirectory: () => true, isFile: () => false }] as any);
-    mockReaddirSync.mockReturnValueOnce([
-      { name: "good-secret", isFile: () => true },
-      { name: "bad-secret", isFile: () => true }
-    ] as any);
-    mockReadFileSync.mockReturnValueOnce("good-value").mockImplementationOnce(() => {
-      throw new Error("Permission denied");
-    });
+  it("should warn when mount point does not exist and failOnError is false", async () => {
+    // Arrange
+    mockExistsSync.mockReturnValue(false);
 
+    // Act
     const secrets = await getPropertiesVolumeSecrets({ failOnError: false });
 
-    expect(secrets).toEqual({
-      "dtsse.good-secret": "good-value"
-    });
-    expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining("Warning: Failed to read"));
+    // Assert
+    expect(consoleWarnSpy).toHaveBeenCalledWith("Warning: Mount point /mnt/secrets does not exist");
+    expect(secrets).toEqual({});
   });
 
-  it("should throw error when file read fails and failOnError is true", async () => {
+  it("should handle file read errors when failOnError is false", async () => {
+    // Arrange
     mockExistsSync.mockReturnValue(true);
-    mockReaddirSync.mockReturnValueOnce([{ name: "dtsse", isDirectory: () => true, isFile: () => false }] as any);
-    mockReaddirSync.mockReturnValueOnce([{ name: "bad-secret", isFile: () => true }] as any);
-    mockReadFileSync.mockImplementation(() => {
+    mockReaddirSync.mockReturnValueOnce([fileEntry("good"), fileEntry("bad")] as any);
+    mockReadFileSync.mockReturnValueOnce("value" as any).mockImplementationOnce(() => {
       throw new Error("Permission denied");
     });
 
-    await expect(getPropertiesVolumeSecrets({ failOnError: true })).rejects.toThrow();
+    // Act
+    const secrets = await getPropertiesVolumeSecrets({ failOnError: false });
+
+    // Assert
+    expect(secrets.good).toBe("value");
+    expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining("Failed to process"));
   });
 
   it("should trim whitespace from file contents", async () => {
+    // Arrange
     mockExistsSync.mockReturnValue(true);
-    mockReaddirSync.mockReturnValueOnce([{ name: "dtsse", isDirectory: () => true, isFile: () => false }] as any);
-    mockReaddirSync.mockReturnValueOnce([{ name: "SECRET", isFile: () => true }] as any);
-    mockReadFileSync.mockReturnValueOnce("  secret value  \n");
+    mockReaddirSync.mockReturnValueOnce([fileEntry("secret")] as any);
+    mockReadFileSync.mockReturnValue("  value with spaces  \n" as any);
 
-    const secrets = await getPropertiesVolumeSecrets({ injectEnvVars: false });
+    // Act
+    const secrets = await getPropertiesVolumeSecrets();
 
-    expect(secrets).toEqual({
-      "dtsse.SECRET": "secret value"
-    });
-  });
-
-  it("should skip non-file entries within vault directories", async () => {
-    mockExistsSync.mockReturnValue(true);
-    mockReaddirSync.mockReturnValueOnce([{ name: "dtsse", isDirectory: () => true, isFile: () => false }] as any);
-    mockReaddirSync.mockReturnValueOnce([
-      { name: "secret", isFile: () => true },
-      { name: "subdirectory", isFile: () => false }
-    ] as any);
-    mockReadFileSync.mockReturnValueOnce("secret-value");
-
-    const secrets = await getPropertiesVolumeSecrets({ injectEnvVars: false });
-
-    expect(secrets).toEqual({
-      "dtsse.secret": "secret-value"
-    });
+    // Assert
+    expect(secrets.secret).toBe("value with spaces");
   });
 
   it("should use custom mount point", async () => {
+    // Arrange
     mockExistsSync.mockReturnValue(true);
-    mockReaddirSync.mockReturnValueOnce([{ name: "vault", isDirectory: () => true, isFile: () => false }] as any);
-    mockReaddirSync.mockReturnValueOnce([{ name: "SECRET", isFile: () => true }] as any);
-    mockReadFileSync.mockReturnValueOnce("value");
+    mockReaddirSync.mockReturnValueOnce([fileEntry("custom-secret")] as any);
+    mockReadFileSync.mockReturnValue("custom-value" as any);
 
-    const secrets = await getPropertiesVolumeSecrets({ mountPoint: "/custom/path", injectEnvVars: false });
+    // Act
+    const secrets = await getPropertiesVolumeSecrets({ mountPoint: "/custom/path" });
 
+    // Assert
     expect(mockExistsSync).toHaveBeenCalledWith("/custom/path");
-    expect(secrets).toEqual({
-      "vault.SECRET": "value"
-    });
+    expect(secrets["custom-secret"]).toBe("custom-value");
   });
 
-  it("should default failOnError to true in production", async () => {
-    const originalEnv = process.env.NODE_ENV;
-    process.env.NODE_ENV = "production";
-
-    mockExistsSync.mockReturnValue(false);
-
-    await expect(getPropertiesVolumeSecrets()).rejects.toThrow("Mount point /mnt/secrets does not exist");
-
-    process.env.NODE_ENV = originalEnv;
-  });
-
-  it("should default injectEnvVars to true", async () => {
+  it("should handle symbolic links as files", async () => {
+    // Arrange
     mockExistsSync.mockReturnValue(true);
-    mockReaddirSync.mockReturnValueOnce([{ name: "dtsse", isDirectory: () => true, isFile: () => false }] as any);
-    mockReaddirSync.mockReturnValueOnce([{ name: "TEST_VAR", isFile: () => true }] as any);
-    mockReadFileSync.mockReturnValueOnce("test-value");
+    mockReaddirSync.mockReturnValueOnce([fileEntry("symlink-file", true)] as any);
+    mockReadFileSync.mockReturnValue("symlink-value" as any);
 
-    delete process.env.TEST_VAR;
-    await getPropertiesVolumeSecrets();
+    // Act
+    const secrets = await getPropertiesVolumeSecrets();
 
-    expect(process.env.TEST_VAR).toBe("test-value");
+    // Assert
+    expect(secrets["symlink-file"]).toBe("symlink-value");
   });
 
   describe("Azure Vault integration", () => {
-    const originalNodeEnv = process.env.NODE_ENV;
-
-    afterEach(() => {
-      process.env.NODE_ENV = originalNodeEnv;
-    });
-
-    it("should load secrets from Azure Vault when chartPath is provided in non-production", async () => {
-      process.env.NODE_ENV = "development";
-      mockExistsSync.mockReturnValue(true);
-      mockAddFromAzureVault.mockImplementation(async (config) => {
-        config.DATABASE_URL = "postgresql://azure:5432/db";
-        config.API_KEY = "azure-api-key";
-      });
-
-      const secrets = await getPropertiesVolumeSecrets({
-        chartPath: "/path/to/chart.yaml",
-        injectEnvVars: false
-      });
-
-      expect(mockAddFromAzureVault).toHaveBeenCalledWith(expect.any(Object), {
-        pathToHelmChart: "/path/to/chart.yaml"
-      });
-      expect(secrets).toEqual({
-        DATABASE_URL: "postgresql://azure:5432/db",
-        API_KEY: "azure-api-key"
-      });
-    });
-
-    it("should inject env vars from Azure Vault when injectEnvVars is true", async () => {
+    it("should load secrets from Azure vault when chartPath is provided in non-production", async () => {
+      // Arrange
       process.env.NODE_ENV = "development";
       mockExistsSync.mockReturnValue(true);
       mockAddFromAzureVault.mockImplementation(async (config) => {
         config.AZURE_SECRET = "azure-value";
       });
 
-      delete process.env.AZURE_SECRET;
-      const secrets = await getPropertiesVolumeSecrets({
-        chartPath: "/path/to/chart.yaml",
-        injectEnvVars: true
-      });
+      // Act
+      const secrets = await getPropertiesVolumeSecrets({ chartPath: "/path/to/chart.yaml" });
 
-      expect(secrets).toEqual({
-        AZURE_SECRET: "azure-value"
-      });
-      expect(process.env.AZURE_SECRET).toBe("azure-value");
+      // Assert
+      expect(mockAddFromAzureVault).toHaveBeenCalled();
+      expect(secrets.AZURE_SECRET).toBe("azure-value");
     });
 
-    it("should not inject env vars from Azure Vault when injectEnvVars is false", async () => {
-      process.env.NODE_ENV = "development";
-      mockExistsSync.mockReturnValue(true);
-      mockAddFromAzureVault.mockImplementation(async (config) => {
-        config.AZURE_SECRET = "azure-value";
-      });
-
-      delete process.env.AZURE_SECRET;
-      const secrets = await getPropertiesVolumeSecrets({
-        chartPath: "/path/to/chart.yaml",
-        injectEnvVars: false
-      });
-
-      expect(secrets).toEqual({
-        AZURE_SECRET: "azure-value"
-      });
-      expect(process.env.AZURE_SECRET).toBeUndefined();
-    });
-
-    it("should skip omitted secrets from Azure Vault", async () => {
-      process.env.NODE_ENV = "development";
-      mockExistsSync.mockReturnValue(true);
-      mockAddFromAzureVault.mockImplementation(async (config) => {
-        config.DATABASE_URL = "postgresql://azure:5432/db";
-        config.OMIT_ME = "should-not-appear";
-        config.API_KEY = "azure-api-key";
-      });
-
-      const secrets = await getPropertiesVolumeSecrets({
-        chartPath: "/path/to/chart.yaml",
-        injectEnvVars: false,
-        omit: ["OMIT_ME"]
-      });
-
-      expect(secrets).toEqual({
-        DATABASE_URL: "postgresql://azure:5432/db",
-        API_KEY: "azure-api-key"
-      });
-    });
-
-    it("should not use Azure Vault in production even with chartPath", async () => {
+    it("should not load from Azure vault in production", async () => {
+      // Arrange
       process.env.NODE_ENV = "production";
       mockExistsSync.mockReturnValue(true);
-      mockReaddirSync.mockReturnValueOnce([{ name: "vault", isDirectory: () => true, isFile: () => false }] as any);
-      mockReaddirSync.mockReturnValueOnce([{ name: "SECRET", isFile: () => true }] as any);
-      mockReadFileSync.mockReturnValueOnce("mount-point-value");
+      mockReaddirSync.mockReturnValueOnce([] as any);
 
+      // Act
+      await getPropertiesVolumeSecrets({ chartPath: "/path/to/chart.yaml" });
+
+      // Assert
+      expect(mockAddFromAzureVault).not.toHaveBeenCalled();
+    });
+
+    it("should not load from Azure vault when chart file does not exist", async () => {
+      // Arrange
+      process.env.NODE_ENV = "development";
+      // chartPath check returns false, mount point check returns true
+      mockExistsSync.mockImplementation((path) => path !== "/nonexistent/chart.yaml");
+      mockReaddirSync.mockReturnValueOnce([] as any);
+
+      // Act
+      await getPropertiesVolumeSecrets({ chartPath: "/nonexistent/chart.yaml" });
+
+      // Assert
+      expect(mockAddFromAzureVault).not.toHaveBeenCalled();
+    });
+
+    it("should apply omit filter to Azure vault secrets", async () => {
+      // Arrange
+      process.env.NODE_ENV = "development";
+      mockExistsSync.mockReturnValue(true);
+      mockAddFromAzureVault.mockImplementation(async (config) => {
+        config.DATABASE_URL = "azure-db-url";
+        config.APP_SECRET = "azure-app-secret";
+      });
+
+      // Act
       const secrets = await getPropertiesVolumeSecrets({
         chartPath: "/path/to/chart.yaml",
-        injectEnvVars: false
-      });
-
-      expect(mockAddFromAzureVault).not.toHaveBeenCalled();
-      expect(secrets).toEqual({
-        "vault.SECRET": "mount-point-value"
-      });
-    });
-
-    it("should not use Azure Vault when chartPath does not exist", async () => {
-      process.env.NODE_ENV = "development";
-      mockExistsSync.mockReturnValueOnce(false); // chartPath does not exist
-      mockExistsSync.mockReturnValueOnce(true); // mount point exists
-      mockReaddirSync.mockReturnValueOnce([{ name: "vault", isDirectory: () => true, isFile: () => false }] as any);
-      mockReaddirSync.mockReturnValueOnce([{ name: "SECRET", isFile: () => true }] as any);
-      mockReadFileSync.mockReturnValueOnce("mount-point-value");
-
-      const secrets = await getPropertiesVolumeSecrets({
-        chartPath: "/path/to/nonexistent.yaml",
-        injectEnvVars: false
-      });
-
-      expect(mockAddFromAzureVault).not.toHaveBeenCalled();
-      expect(secrets).toEqual({
-        "vault.SECRET": "mount-point-value"
-      });
-    });
-  });
-
-  describe("omit parameter", () => {
-    it("should not omit direct files from properties volume even when omit is specified", async () => {
-      mockExistsSync.mockReturnValue(true);
-      mockReaddirSync.mockReturnValueOnce([
-        { name: "keep-this", isDirectory: () => false, isFile: () => true },
-        { name: "omit-this", isDirectory: () => false, isFile: () => true }
-      ] as any);
-      mockReadFileSync.mockReturnValueOnce("keep-value").mockReturnValueOnce("omit-value");
-
-      const secrets = await getPropertiesVolumeSecrets({
-        injectEnvVars: false,
-        omit: ["omit-this"]
-      });
-
-      expect(secrets).toEqual({
-        "keep-this": "keep-value",
-        "omit-this": "omit-value"
-      });
-    });
-
-    it("should not omit vault secrets from properties volume even when omit is specified", async () => {
-      mockExistsSync.mockReturnValue(true);
-      mockReaddirSync.mockReturnValueOnce([{ name: "vault", isDirectory: () => true, isFile: () => false }] as any);
-      mockReaddirSync.mockReturnValueOnce([
-        { name: "SECRET1", isFile: () => true },
-        { name: "SECRET2", isFile: () => true }
-      ] as any);
-      mockReadFileSync.mockReturnValueOnce("value1").mockReturnValueOnce("value2");
-
-      const secrets = await getPropertiesVolumeSecrets({
-        injectEnvVars: false,
-        omit: ["vault.SECRET1"]
-      });
-
-      expect(secrets).toEqual({
-        "vault.SECRET1": "value1",
-        "vault.SECRET2": "value2"
-      });
-    });
-
-    it("should not omit secrets by last segment from properties volume", async () => {
-      mockExistsSync.mockReturnValue(true);
-      mockReaddirSync.mockReturnValueOnce([{ name: "vault", isDirectory: () => true, isFile: () => false }] as any);
-      mockReaddirSync.mockReturnValueOnce([
-        { name: "DATABASE_URL", isFile: () => true },
-        { name: "API_KEY", isFile: () => true }
-      ] as any);
-      mockReadFileSync.mockReturnValueOnce("db-value").mockReturnValueOnce("api-value");
-
-      const secrets = await getPropertiesVolumeSecrets({
-        injectEnvVars: false,
         omit: ["DATABASE_URL"]
       });
 
-      expect(secrets).toEqual({
-        "vault.DATABASE_URL": "db-value",
-        "vault.API_KEY": "api-value"
-      });
+      // Assert
+      expect(secrets.DATABASE_URL).toBeUndefined();
+      expect(secrets.APP_SECRET).toBe("azure-app-secret");
     });
 
-    it("should not omit multiple secrets from properties volume", async () => {
+    it("should inject Azure vault secrets into process.env", async () => {
+      // Arrange
+      process.env.NODE_ENV = "development";
+      delete process.env.AZURE_INJECTED;
       mockExistsSync.mockReturnValue(true);
-      mockReaddirSync.mockReturnValueOnce([{ name: "vault", isDirectory: () => true, isFile: () => false }] as any);
-      mockReaddirSync.mockReturnValueOnce([
-        { name: "SECRET1", isFile: () => true },
-        { name: "SECRET2", isFile: () => true },
-        { name: "SECRET3", isFile: () => true }
-      ] as any);
-      mockReadFileSync.mockReturnValueOnce("value1").mockReturnValueOnce("value2").mockReturnValueOnce("value3");
-
-      const secrets = await getPropertiesVolumeSecrets({
-        injectEnvVars: false,
-        omit: ["SECRET1", "vault.SECRET3"]
+      mockAddFromAzureVault.mockImplementation(async (config) => {
+        config.AZURE_INJECTED = "injected-value";
       });
 
-      expect(secrets).toEqual({
-        "vault.SECRET1": "value1",
-        "vault.SECRET2": "value2",
-        "vault.SECRET3": "value3"
-      });
-    });
+      // Act
+      await getPropertiesVolumeSecrets({ chartPath: "/path/to/chart.yaml" });
 
-    it("should not omit when omit array is empty", async () => {
-      mockExistsSync.mockReturnValue(true);
-      mockReaddirSync.mockReturnValueOnce([{ name: "vault", isDirectory: () => true, isFile: () => false }] as any);
-      mockReaddirSync.mockReturnValueOnce([
-        { name: "SECRET1", isFile: () => true },
-        { name: "SECRET2", isFile: () => true }
-      ] as any);
-      mockReadFileSync.mockReturnValueOnce("value1").mockReturnValueOnce("value2");
-
-      const secrets = await getPropertiesVolumeSecrets({
-        injectEnvVars: false,
-        omit: []
-      });
-
-      expect(secrets).toEqual({
-        "vault.SECRET1": "value1",
-        "vault.SECRET2": "value2"
-      });
+      // Assert
+      expect(process.env.AZURE_INJECTED).toBe("injected-value");
     });
   });
 
-  describe("top-level error handling", () => {
-    it("should handle errors when processing top-level entries with failOnError=false", async () => {
-      mockExistsSync.mockReturnValue(true);
-      mockReaddirSync.mockReturnValueOnce([
-        { name: "good-file", isDirectory: () => false, isFile: () => true },
-        {
-          name: "bad-entry",
-          isDirectory: () => {
-            throw new Error("Cannot determine if directory");
-          },
-          isFile: () => false
-        }
-      ] as any);
-      mockReadFileSync.mockReturnValueOnce("good-value");
+  describe("Error handling", () => {
+    it("should default failOnError to true in production", async () => {
+      // Arrange
+      process.env.NODE_ENV = "production";
+      mockExistsSync.mockReturnValue(false);
 
-      const secrets = await getPropertiesVolumeSecrets({ failOnError: false });
-
-      expect(secrets).toEqual({
-        "good-file": "good-value"
-      });
-      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining("Warning: Failed to process"));
+      // Act & Assert
+      await expect(getPropertiesVolumeSecrets()).rejects.toThrow("Mount point /mnt/secrets does not exist");
     });
 
-    it("should throw error when processing top-level entries with failOnError=true", async () => {
-      mockExistsSync.mockReturnValue(true);
-      mockReaddirSync.mockReturnValueOnce([
-        {
-          name: "bad-entry",
-          isDirectory: () => {
-            throw new Error("Cannot determine if directory");
-          },
-          isFile: () => false
-        }
-      ] as any);
+    it("should throw when existsSync throws and failOnError is true", async () => {
+      // Arrange
+      mockExistsSync.mockImplementation(() => {
+        throw new Error("Unexpected fs error");
+      });
 
+      // Act & Assert
+      await expect(getPropertiesVolumeSecrets({ failOnError: true })).rejects.toThrow("Unexpected fs error");
+    });
+
+    it("should throw when Azure vault fails and failOnError is true", async () => {
+      // Arrange
+      process.env.NODE_ENV = "development";
+      mockExistsSync.mockReturnValue(true);
+      mockAddFromAzureVault.mockRejectedValue(new Error("Azure auth failed"));
+
+      // Act & Assert
+      await expect(getPropertiesVolumeSecrets({ chartPath: "/path/to/chart.yaml", failOnError: true })).rejects.toThrow(
+        "Failed to load secrets from Azure Vault: Error: Azure auth failed"
+      );
+    });
+
+    it("should warn when Azure vault fails and failOnError is false", async () => {
+      // Arrange
+      process.env.NODE_ENV = "development";
+      // First existsSync for chartPath returns true, second for mountPoint returns false
+      mockExistsSync.mockReturnValueOnce(true).mockReturnValueOnce(false);
+      mockAddFromAzureVault.mockRejectedValue(new Error("Azure auth failed"));
+
+      // Act
+      const secrets = await getPropertiesVolumeSecrets({ chartPath: "/path/to/chart.yaml", failOnError: false });
+
+      // Assert
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining("Failed to load secrets from Azure Vault"));
+      expect(secrets).toEqual({});
+    });
+
+    it("should throw when reading directory fails and failOnError is true", async () => {
+      // Arrange
+      mockExistsSync.mockReturnValue(true);
+      mockReaddirSync.mockReturnValueOnce([dirEntry("vault", true)] as any);
+      mockReaddirSync.mockImplementationOnce(() => {
+        throw new Error("Permission denied");
+      });
+
+      // Act & Assert
       await expect(getPropertiesVolumeSecrets({ failOnError: true })).rejects.toThrow("Failed to load secrets from /mnt/secrets");
+    });
+
+    it("should warn when reading directory file fails and failOnError is false", async () => {
+      // Arrange
+      mockExistsSync.mockReturnValue(true);
+      mockReaddirSync.mockReturnValueOnce([dirEntry("vault", true)] as any);
+      mockReaddirSync.mockReturnValueOnce([fileEntry("secret1"), fileEntry("secret2")] as any);
+      mockReadFileSync.mockReturnValueOnce("value1" as any).mockImplementationOnce(() => {
+        throw new Error("File read error");
+      });
+
+      // Act
+      const secrets = await getPropertiesVolumeSecrets({ failOnError: false });
+
+      // Assert
+      expect(secrets["vault.secret1"]).toBe("value1");
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining("Failed to read"));
+    });
+
+    it("should throw when reading directory file fails and failOnError is true", async () => {
+      // Arrange
+      mockExistsSync.mockReturnValue(true);
+      mockReaddirSync.mockReturnValueOnce([dirEntry("vault", true)] as any);
+      mockReaddirSync.mockReturnValueOnce([fileEntry("secret1")] as any);
+      mockReadFileSync.mockImplementationOnce(() => {
+        throw new Error("File read error");
+      });
+
+      // Act & Assert
+      await expect(getPropertiesVolumeSecrets({ failOnError: true })).rejects.toThrow();
+    });
+  });
+
+  describe("shouldOmit function edge cases", () => {
+    it("should omit secrets by last part of key when key contains dots", async () => {
+      // Arrange
+      process.env.NODE_ENV = "development";
+      mockExistsSync.mockReturnValue(true);
+      mockAddFromAzureVault.mockImplementation(async (config) => {
+        config["vault.DATABASE_URL"] = "db-url";
+        config["vault.APP_SECRET"] = "secret";
+      });
+
+      // Act
+      const secrets = await getPropertiesVolumeSecrets({
+        chartPath: "/path/to/chart.yaml",
+        omit: ["DATABASE_URL"]
+      });
+
+      // Assert
+      expect(secrets["vault.DATABASE_URL"]).toBeUndefined();
+      expect(secrets["vault.APP_SECRET"]).toBe("secret");
+    });
+
+    it("should not omit when omit array is empty", async () => {
+      // Arrange
+      process.env.NODE_ENV = "development";
+      mockExistsSync.mockReturnValue(true);
+      mockAddFromAzureVault.mockImplementation(async (config) => {
+        config.DATABASE_URL = "db-url";
+      });
+
+      // Act
+      const secrets = await getPropertiesVolumeSecrets({
+        chartPath: "/path/to/chart.yaml",
+        omit: []
+      });
+
+      // Assert
+      expect(secrets.DATABASE_URL).toBe("db-url");
+    });
+
+    it("should skip non-string values from Azure vault", async () => {
+      // Arrange
+      process.env.NODE_ENV = "development";
+      mockExistsSync.mockReturnValue(true);
+      mockAddFromAzureVault.mockImplementation(async (config) => {
+        config.STRING_VALUE = "string";
+        config.NUMBER_VALUE = 123;
+        config.OBJECT_VALUE = { nested: "value" };
+      });
+
+      // Act
+      const secrets = await getPropertiesVolumeSecrets({ chartPath: "/path/to/chart.yaml" });
+
+      // Assert
+      expect(secrets.STRING_VALUE).toBe("string");
+      expect(secrets.NUMBER_VALUE).toBeUndefined();
+      expect(secrets.OBJECT_VALUE).toBeUndefined();
+    });
+  });
+
+  describe("Alias mapping from helm chart in production filesystem path", () => {
+    it("should use alias as env var name when secret name has a corresponding alias in the helm chart", async () => {
+      // Arrange
+      process.env.NODE_ENV = "production";
+      delete process.env.REDIS_URL;
+      const helmChart = `nodejs:\n  keyVaults:\n    cath:\n      secrets:\n        - name: redis-url\n          alias: REDIS_URL\n`;
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValueOnce(helmChart as any).mockReturnValueOnce("rediss://:key@host:6380" as any);
+      mockReaddirSync.mockReturnValueOnce([dirEntry("cath", true)] as any);
+      mockReaddirSync.mockReturnValueOnce([fileEntry("redis-url")] as any);
+
+      // Act
+      const secrets = await getPropertiesVolumeSecrets({ chartPath: "/app/helm/values.yaml" });
+
+      // Assert - alias REDIS_URL is used as env var, not the raw file name redis-url
+      expect(process.env.REDIS_URL).toBe("rediss://:key@host:6380");
+      expect(process.env["redis-url"]).toBeUndefined();
+      expect(secrets["cath.redis-url"]).toBe("rediss://:key@host:6380");
+    });
+
+    it("should fall back to file name as env var when no alias is defined in the helm chart", async () => {
+      // Arrange
+      process.env.NODE_ENV = "production";
+      const helmChart = `nodejs:\n  keyVaults:\n    cath:\n      secrets:\n        - name: app-secret\n`;
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValueOnce(helmChart as any).mockReturnValueOnce("secret-value" as any);
+      mockReaddirSync.mockReturnValueOnce([dirEntry("cath", true)] as any);
+      mockReaddirSync.mockReturnValueOnce([fileEntry("app-secret")] as any);
+
+      // Act
+      await getPropertiesVolumeSecrets({ chartPath: "/app/helm/values.yaml" });
+
+      // Assert - no alias, so raw file name is used
+      expect(process.env["app-secret"]).toBe("secret-value");
+    });
+  });
+
+  describe("Symbolic link handling in directories", () => {
+    it("should handle symbolic links in vault directories", async () => {
+      // Arrange
+      mockExistsSync.mockReturnValue(true);
+      mockReaddirSync.mockReturnValueOnce([dirEntry("vault", true)] as any);
+      mockReaddirSync.mockReturnValueOnce([fileEntry("regular-file"), fileEntry("symlink-file", true)] as any);
+      mockReadFileSync.mockReturnValueOnce("regular-value" as any).mockReturnValueOnce("symlink-value" as any);
+
+      // Act
+      const secrets = await getPropertiesVolumeSecrets();
+
+      // Assert
+      expect(secrets["vault.regular-file"]).toBe("regular-value");
+      expect(secrets["vault.symlink-file"]).toBe("symlink-value");
     });
   });
 });

--- a/libs/cloud-native-platform/src/properties-volume/properties.test.ts
+++ b/libs/cloud-native-platform/src/properties-volume/properties.test.ts
@@ -26,6 +26,13 @@ function fileEntry(name: string, isSymlink = false) {
   return dirEntry(name, false, isSymlink);
 }
 
+function restoreEnv(original: NodeJS.ProcessEnv) {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in original)) delete process.env[key];
+  }
+  Object.assign(process.env, original);
+}
+
 describe("getPropertiesVolumeSecrets", () => {
   let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
   const originalEnv = { ...process.env };
@@ -33,12 +40,12 @@ describe("getPropertiesVolumeSecrets", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    process.env = { ...originalEnv };
+    restoreEnv(originalEnv);
   });
 
   afterEach(() => {
     consoleWarnSpy.mockRestore();
-    process.env = originalEnv;
+    restoreEnv(originalEnv);
   });
 
   it("should read vault subdirectories with prefixed keys", async () => {

--- a/libs/cloud-native-platform/src/properties-volume/properties.ts
+++ b/libs/cloud-native-platform/src/properties-volume/properties.ts
@@ -1,8 +1,7 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { load as yamlLoad } from "js-yaml";
 import { addFromAzureVault } from "./azure-vault.js";
-import { deepSearch } from "./utils.js";
+import { parseVaultsFromHelmChart } from "./helm-chart.js";
 
 const DEFAULT_MOUNT_POINT = "/mnt/secrets";
 
@@ -25,27 +24,13 @@ export async function getPropertiesVolumeSecrets(options: GetSecretsOptions = {}
 
 function buildAliasMap(chartPath: string): Map<string, string> {
   try {
-    const chart = yamlLoad(readFileSync(chartPath, "utf8"));
-    const aliasedSecrets = deepSearch(chart, "keyVaults").flatMap(extractAliasedSecrets);
-    return new Map(aliasedSecrets.map(({ name, alias }) => [name, alias]));
+    const aliases = parseVaultsFromHelmChart(chartPath)
+      .vaults.flatMap((vault) => vault.secrets)
+      .filter((secret): secret is Required<typeof secret> => secret.alias !== undefined);
+    return new Map(aliases.map(({ name, alias }) => [name, alias]));
   } catch {
     return new Map();
   }
-}
-
-function extractAliasedSecrets(vaults: unknown): AliasedSecret[] {
-  if (!isRecord(vaults)) return [];
-  return Object.values(vaults)
-    .flatMap((vault) => (isRecord(vault) && Array.isArray(vault.secrets) ? vault.secrets : []))
-    .filter(isAliasedSecret);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function isAliasedSecret(value: unknown): value is AliasedSecret {
-  return isRecord(value) && typeof value.name === "string" && typeof value.alias === "string";
 }
 
 async function tryLoadFromAzureVault(
@@ -192,9 +177,4 @@ export interface Secrets {
 
 export interface Config {
   [key: string]: any;
-}
-
-interface AliasedSecret {
-  name: string;
-  alias: string;
 }

--- a/libs/cloud-native-platform/src/properties-volume/properties.ts
+++ b/libs/cloud-native-platform/src/properties-volume/properties.ts
@@ -1,6 +1,8 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { load as yamlLoad } from "js-yaml";
 import { addFromAzureVault } from "./azure-vault.js";
+import { deepSearch } from "./utils.js";
 
 const DEFAULT_MOUNT_POINT = "/mnt/secrets";
 
@@ -8,44 +10,110 @@ export async function getPropertiesVolumeSecrets(options: GetSecretsOptions = {}
   const isProd = process.env.NODE_ENV === "production";
   const { mountPoint = DEFAULT_MOUNT_POINT, failOnError = isProd, injectEnvVars = true, chartPath, omit = [] } = options;
 
-  if (chartPath && !isProd && existsSync(chartPath)) {
-    try {
-      return await loadFromAzureVault(chartPath, injectEnvVars, omit);
-    } catch (error) {
-      if (failOnError) {
-        throw new Error(`Failed to load secrets from Azure Vault: ${error}`);
-      }
-      console.warn(`Warning: Failed to load secrets from Azure Vault: ${error}`);
-    }
+  const azureResult = await tryLoadFromAzureVault(chartPath, isProd, injectEnvVars, omit, failOnError);
+  if (azureResult) {
+    return azureResult;
   }
 
   if (!existsSync(mountPoint)) {
-    const message = `Mount point ${mountPoint} does not exist`;
-    if (failOnError) throw new Error(message);
-    console.warn(`Warning: ${message}`);
-    return {};
+    return handleMissingMountPoint(mountPoint, failOnError);
   }
 
+  const aliasMap = chartPath ? buildAliasMap(chartPath) : new Map<string, string>();
+  return loadSecretsFromMountPoint(mountPoint, injectEnvVars, failOnError, aliasMap);
+}
+
+function buildAliasMap(chartPath: string): Map<string, string> {
+  const aliasMap = new Map<string, string>();
+  try {
+    const helmChartContent = readFileSync(chartPath, "utf8");
+    const helmChart = yamlLoad(helmChartContent) as any;
+    const keyVaultsList = deepSearch(helmChart, "keyVaults");
+    for (const keyVaultsObj of keyVaultsList) {
+      if (keyVaultsObj && typeof keyVaultsObj === "object") {
+        for (const vaultConfig of Object.values(keyVaultsObj) as any[]) {
+          if (vaultConfig?.secrets && Array.isArray(vaultConfig.secrets)) {
+            for (const secret of vaultConfig.secrets) {
+              if (secret?.name && secret?.alias) {
+                aliasMap.set(secret.name, secret.alias);
+              }
+            }
+          }
+        }
+      }
+    }
+  } catch {
+    // If chart can't be read, proceed without alias mapping
+  }
+  return aliasMap;
+}
+
+async function tryLoadFromAzureVault(
+  chartPath: string | undefined,
+  isProd: boolean,
+  injectEnvVars: boolean,
+  omit: string[],
+  failOnError: boolean
+): Promise<Secrets | null> {
+  if (!chartPath || isProd || !existsSync(chartPath)) {
+    return null;
+  }
+
+  try {
+    return await loadFromAzureVault(chartPath, injectEnvVars, omit);
+  } catch (error) {
+    if (failOnError) {
+      throw new Error(`Failed to load secrets from Azure Vault: ${error}`);
+    }
+    console.warn(`Warning: Failed to load secrets from Azure Vault: ${error}`);
+    return null;
+  }
+}
+
+function handleMissingMountPoint(mountPoint: string, failOnError: boolean): Secrets {
+  const message = `Mount point ${mountPoint} does not exist`;
+  if (failOnError) {
+    throw new Error(message);
+  }
+  console.warn(`Warning: ${message}`);
+  return {};
+}
+
+function loadSecretsFromMountPoint(mountPoint: string, injectEnvVars: boolean, failOnError: boolean, aliasMap: Map<string, string>): Secrets {
   const secrets: Secrets = {};
   const entries = readdirSync(mountPoint, { withFileTypes: true });
 
   for (const entry of entries) {
     const path = join(mountPoint, entry.name);
-
-    try {
-      if (entry.isDirectory()) {
-        readSecretsFromDirectory(path, entry.name, injectEnvVars, secrets, failOnError);
-      } else if (entry.isFile() || entry.isSymbolicLink?.()) {
-        const content = readSecretFile(path);
-        processSecret(entry.name, content, injectEnvVars, secrets);
-      }
-    } catch (error) {
-      if (failOnError) throw new Error(`Failed to load secrets from ${mountPoint}: ${error}`);
-      console.warn(`Warning: Failed to process ${path}: ${error}`);
-    }
+    processEntry(entry, path, injectEnvVars, secrets, failOnError, mountPoint, aliasMap);
   }
 
   return secrets;
+}
+
+function processEntry(
+  entry: { name: string; isDirectory: () => boolean; isFile: () => boolean; isSymbolicLink?: () => boolean },
+  path: string,
+  injectEnvVars: boolean,
+  secrets: Secrets,
+  failOnError: boolean,
+  mountPoint: string,
+  aliasMap: Map<string, string>
+): void {
+  try {
+    if (entry.isDirectory()) {
+      readSecretsFromDirectory(path, entry.name, injectEnvVars, secrets, failOnError, aliasMap);
+    } else if (entry.isFile() || entry.isSymbolicLink?.()) {
+      const content = readSecretFile(path);
+      const alias = aliasMap.get(entry.name);
+      processSecret(entry.name, content, injectEnvVars, secrets, alias);
+    }
+  } catch (error) {
+    if (failOnError) {
+      throw new Error(`Failed to load secrets from ${mountPoint}: ${error}`);
+    }
+    console.warn(`Warning: Failed to process ${path}: ${error}`);
+  }
 }
 
 async function loadFromAzureVault(chartPath: string, injectEnvVars: boolean, omit: string[]): Promise<Secrets> {
@@ -64,16 +132,24 @@ async function loadFromAzureVault(chartPath: string, injectEnvVars: boolean, omi
   return secrets;
 }
 
-function readSecretsFromDirectory(dirPath: string, vaultName: string, injectEnvVars: boolean, secrets: Secrets, failOnError: boolean): void {
+function readSecretsFromDirectory(
+  dirPath: string,
+  vaultName: string,
+  injectEnvVars: boolean,
+  secrets: Secrets,
+  failOnError: boolean,
+  aliasMap: Map<string, string>
+): void {
   // Filter for files and symlinks, but exclude CSI driver internal entries (start with ..)
   const files = readdirSync(dirPath, { withFileTypes: true }).filter((f) => !f.name.startsWith("..") && (f.isFile() || f.isSymbolicLink?.()));
 
   for (const file of files) {
     const secretKey = `${vaultName}.${file.name}`;
+    const alias = aliasMap.get(file.name);
 
     try {
       const content = readSecretFile(join(dirPath, file.name));
-      processSecret(secretKey, content, injectEnvVars, secrets);
+      processSecret(secretKey, content, injectEnvVars, secrets, alias);
     } catch (error) {
       if (failOnError) throw error;
       console.warn(`Warning: Failed to read ${join(dirPath, file.name)}: ${error}`);
@@ -85,11 +161,10 @@ function readSecretFile(path: string): string {
   return readFileSync(path, "utf8").trim();
 }
 
-function processSecret(key: string, value: string, injectEnvVars: boolean, secrets: Secrets): void {
+function processSecret(key: string, value: string, injectEnvVars: boolean, secrets: Secrets, alias?: string): void {
   secrets[key] = value;
   if (injectEnvVars) {
-    const parts = key.split(".");
-    const envKey = parts[parts.length - 1];
+    const envKey = alias ?? key.split(".").at(-1) ?? key;
     process.env[envKey] = value;
   }
 }
@@ -97,15 +172,8 @@ function processSecret(key: string, value: string, injectEnvVars: boolean, secre
 function shouldOmit(key: string, omit: string[]): boolean {
   if (omit.length === 0) return false;
 
-  for (const omitKey of omit) {
-    if (key === omitKey) return true;
-
-    const parts = key.split(".");
-    const lastName = parts[parts.length - 1];
-    if (lastName === omitKey) return true;
-  }
-
-  return false;
+  const lastName = key.split(".").at(-1) ?? key;
+  return omit.includes(key) || omit.includes(lastName);
 }
 
 export interface GetSecretsOptions {

--- a/libs/cloud-native-platform/src/properties-volume/properties.ts
+++ b/libs/cloud-native-platform/src/properties-volume/properties.ts
@@ -8,9 +8,9 @@ const DEFAULT_MOUNT_POINT = "/mnt/secrets";
 
 export async function getPropertiesVolumeSecrets(options: GetSecretsOptions = {}): Promise<Secrets> {
   const isProd = process.env.NODE_ENV === "production";
-  const { mountPoint = DEFAULT_MOUNT_POINT, failOnError = isProd, injectEnvVars = true, chartPath, omit = [] } = options;
+  const { mountPoint = DEFAULT_MOUNT_POINT, failOnError = isProd, injectEnvVars = true, chartPath, omit = [], vaultUriSuffix } = options;
 
-  const azureResult = await tryLoadFromAzureVault(chartPath, isProd, injectEnvVars, omit, failOnError);
+  const azureResult = await tryLoadFromAzureVault(chartPath, isProd, injectEnvVars, omit, failOnError, vaultUriSuffix);
   if (azureResult) {
     return azureResult;
   }
@@ -24,28 +24,28 @@ export async function getPropertiesVolumeSecrets(options: GetSecretsOptions = {}
 }
 
 function buildAliasMap(chartPath: string): Map<string, string> {
-  const aliasMap = new Map<string, string>();
   try {
-    const helmChartContent = readFileSync(chartPath, "utf8");
-    const helmChart = yamlLoad(helmChartContent) as any;
-    const keyVaultsList = deepSearch(helmChart, "keyVaults");
-    for (const keyVaultsObj of keyVaultsList) {
-      if (keyVaultsObj && typeof keyVaultsObj === "object") {
-        for (const vaultConfig of Object.values(keyVaultsObj) as any[]) {
-          if (vaultConfig?.secrets && Array.isArray(vaultConfig.secrets)) {
-            for (const secret of vaultConfig.secrets) {
-              if (secret?.name && secret?.alias) {
-                aliasMap.set(secret.name, secret.alias);
-              }
-            }
-          }
-        }
-      }
-    }
+    const chart = yamlLoad(readFileSync(chartPath, "utf8"));
+    const aliasedSecrets = deepSearch(chart, "keyVaults").flatMap(extractAliasedSecrets);
+    return new Map(aliasedSecrets.map(({ name, alias }) => [name, alias]));
   } catch {
-    // If chart can't be read, proceed without alias mapping
+    return new Map();
   }
-  return aliasMap;
+}
+
+function extractAliasedSecrets(vaults: unknown): AliasedSecret[] {
+  if (!isRecord(vaults)) return [];
+  return Object.values(vaults)
+    .flatMap((vault) => (isRecord(vault) && Array.isArray(vault.secrets) ? vault.secrets : []))
+    .filter(isAliasedSecret);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isAliasedSecret(value: unknown): value is AliasedSecret {
+  return isRecord(value) && typeof value.name === "string" && typeof value.alias === "string";
 }
 
 async function tryLoadFromAzureVault(
@@ -53,14 +53,15 @@ async function tryLoadFromAzureVault(
   isProd: boolean,
   injectEnvVars: boolean,
   omit: string[],
-  failOnError: boolean
+  failOnError: boolean,
+  vaultUriSuffix: string | undefined
 ): Promise<Secrets | null> {
   if (!chartPath || isProd || !existsSync(chartPath)) {
     return null;
   }
 
   try {
-    return await loadFromAzureVault(chartPath, injectEnvVars, omit);
+    return await loadFromAzureVault(chartPath, injectEnvVars, omit, vaultUriSuffix);
   } catch (error) {
     if (failOnError) {
       throw new Error(`Failed to load secrets from Azure Vault: ${error}`);
@@ -116,9 +117,9 @@ function processEntry(
   }
 }
 
-async function loadFromAzureVault(chartPath: string, injectEnvVars: boolean, omit: string[]): Promise<Secrets> {
+async function loadFromAzureVault(chartPath: string, injectEnvVars: boolean, omit: string[], vaultUriSuffix: string | undefined): Promise<Secrets> {
   const config: Config = {};
-  await addFromAzureVault(config, { pathToHelmChart: chartPath });
+  await addFromAzureVault(config, { pathToHelmChart: chartPath, vaultUriSuffix });
 
   const secrets: Secrets = {};
   for (const [key, value] of Object.entries(config)) {
@@ -182,6 +183,7 @@ export interface GetSecretsOptions {
   injectEnvVars?: boolean;
   chartPath?: string;
   omit?: string[];
+  vaultUriSuffix?: string;
 }
 
 export interface Secrets {
@@ -190,4 +192,9 @@ export interface Secrets {
 
 export interface Config {
   [key: string]: any;
+}
+
+interface AliasedSecret {
+  name: string;
+  alias: string;
 }

--- a/libs/cloud-native-platform/tsconfig.json
+++ b/libs/cloud-native-platform/tsconfig.json
@@ -3,8 +3,9 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
-    "composite": true
+    "composite": true,
+    "declarationMap": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
       "@hmcts/postgres-prisma": ["./libs/postgres-prisma/src"],
       "@hmcts/web": ["./apps/web/src"],
       "@hmcts/express-govuk-starter": ["./libs/express-govuk-starter/src"],
-      "@hmcts/cloud-native-platform": ["./libs/cloud-native-platform/src"],
+      "@hmcts-cft/cloud-native-platform": ["./libs/cloud-native-platform/src"],
       "@hmcts-cft/simple-router": ["./libs/simple-router/src"],
       "@hmcts/onboarding": ["./libs/onboarding/src"]
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1032,6 +1032,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@hmcts-cft/cloud-native-platform@workspace:*, @hmcts-cft/cloud-native-platform@workspace:libs/cloud-native-platform":
+  version: 0.0.0-use.local
+  resolution: "@hmcts-cft/cloud-native-platform@workspace:libs/cloud-native-platform"
+  dependencies:
+    "@azure/identity": "npm:^4.2.1"
+    "@azure/keyvault-secrets": "npm:^4.7.0"
+    "@types/express": "npm:5.0.6"
+    "@types/js-yaml": "npm:^4.0.9"
+    applicationinsights: "npm:3.14.0"
+    js-yaml: "npm:^4.1.0"
+  peerDependencies:
+    config: ^3.3.12 || ^4.0.0
+    express: ^5.1.0
+  languageName: unknown
+  linkType: soft
+
 "@hmcts-cft/simple-router@workspace:*, @hmcts-cft/simple-router@workspace:libs/simple-router":
   version: 0.0.0-use.local
   resolution: "@hmcts-cft/simple-router@workspace:libs/simple-router"
@@ -1046,8 +1062,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@hmcts/api@workspace:apps/api"
   dependencies:
+    "@hmcts-cft/cloud-native-platform": "workspace:*"
     "@hmcts-cft/simple-router": "workspace:*"
-    "@hmcts/cloud-native-platform": "workspace:*"
     "@hmcts/onboarding": "workspace:*"
     "@hmcts/postgres-prisma": "workspace:*"
     "@types/compression": "npm:1.8.1"
@@ -1063,22 +1079,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@hmcts/cloud-native-platform@workspace:*, @hmcts/cloud-native-platform@workspace:libs/cloud-native-platform":
-  version: 0.0.0-use.local
-  resolution: "@hmcts/cloud-native-platform@workspace:libs/cloud-native-platform"
-  dependencies:
-    "@azure/identity": "npm:^4.2.1"
-    "@azure/keyvault-secrets": "npm:^4.7.0"
-    "@types/express": "npm:5.0.6"
-    "@types/js-yaml": "npm:^4.0.9"
-    applicationinsights: "npm:3.14.0"
-    js-yaml: "npm:^4.1.0"
-  peerDependencies:
-    config: ^3.3.12 || ^4.0.0
-    express: ^5.1.0
-  languageName: unknown
-  linkType: soft
-
 "@hmcts/cookie-manager@npm:1.1.0":
   version: 1.1.0
   resolution: "@hmcts/cookie-manager@npm:1.1.0"
@@ -1090,7 +1090,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@hmcts/crons@workspace:apps/crons"
   dependencies:
-    "@hmcts/cloud-native-platform": "workspace:*"
+    "@hmcts-cft/cloud-native-platform": "workspace:*"
     "@hmcts/postgres-prisma": "workspace:*"
     "@types/config": "npm:4.4.0"
     config: "npm:4.4.1"
@@ -1170,8 +1170,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@hmcts/web@workspace:apps/web"
   dependencies:
+    "@hmcts-cft/cloud-native-platform": "workspace:*"
     "@hmcts-cft/simple-router": "workspace:*"
-    "@hmcts/cloud-native-platform": "workspace:*"
     "@hmcts/cookie-manager": "npm:1.1.0"
     "@hmcts/express-govuk-starter": "workspace:*"
     "@hmcts/onboarding": "workspace:*"


### PR DESCRIPTION
## Summary

Brings the template's `@hmcts/cloud-native-platform` library up to date with improvements developed in cath-service, plus a few cleanups on the way through.

### New features

- **`trackException(error, properties?)`** — free-function exception tracker for use in route handlers where the `MonitoringService` instance isn't directly available. Calls `appInsights.defaultClient.trackException` when AI is initialised, falls back to `console.error` otherwise.

- **Helm chart alias mapping** in `getPropertiesVolumeSecrets`. When a Helm values file declares vault secrets as `{ name, alias }`, the alias is used as the injected env var name. Without an alias, behaviour is unchanged.

  ```yaml
  keyVaults:
    my-app:
      secrets:
        - name: redis-url
          alias: REDIS_URL
  ```

  Previously the env var would be `redis-url`; now it's `REDIS_URL`.

- **Configurable vault URI suffix** via `AzureVaultOptions.vaultUriSuffix` (default `"aat"`), also surfaced on `GetSecretsOptions`. Lets non-AAT environments (e.g. STG) override the suffix without forking the library.

### Cleanups

- `buildAliasMap` rewritten with `flatMap` + type guards (`isRecord`, `isAliasedSecret`) instead of 5 levels of nested loops and `any` casts.

- `hc.raw()` signature tightened from `() => Promise<HealthStatus \| unknown> \| HealthStatus \| unknown` to `() => Promise<HealthStatus> \| HealthStatus`. Implementation no longer coerces unknown results to `"UP"` — callers must return a `HealthStatus` (or throw, which still resolves to `"DOWN"`). The redis check in `apps/web` was updated accordingly; the now-obsolete "void = UP" tests were dropped.

- `properties.ts` refactored into smaller focused helpers (`tryLoadFromAzureVault`, `buildAliasMap`, `handleMissingMountPoint`, `loadSecretsFromMountPoint`, `processEntry`).

## Test plan

- [x] `yarn test` — 121 cloud-native-platform unit tests pass (was ~109; +13 for `trackException`, +1 for vaultUriSuffix, +12 for alias-map, −2 for the dropped void-coercion tests, +rest from refactor)
- [x] `yarn build` — full monorepo build clean
- [x] `yarn lint` — no new warnings
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Exception tracking now integrates with Application Insights for improved error monitoring
  * Azure Key Vault URI suffix is now customisable
  * Helm chart parsing now supports secret alias mapping

* **Refactor**
  * Enhanced secret-loading architecture with improved Helm chart integration and better support for vault configuration options

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmcts/expressjs-monorepo-template/pull/641)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->