### PR TITLE
fix: add publishConfig.registry to the three new libs

### DIFF
--- a/libs/express-govuk-starter/package.json
+++ b/libs/express-govuk-starter/package.json
@@ -21,6 +21,9 @@
     "dist",
     "README.md"
   ],
+  "publishConfig": {
+    "registry": "https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/npm/registry/"
+  },
   "scripts": {
     "build": "tsc && cp -r src/govuk-frontend/views dist/govuk-frontend/ && cp -r src/cookies/views dist/cookies/",
     "dev": "tsc --watch",

--- a/libs/express-session-postgres/package.json
+++ b/libs/express-session-postgres/package.json
@@ -21,6 +21,9 @@
     "dist",
     "README.md"
   ],
+  "publishConfig": {
+    "registry": "https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/npm/registry/"
+  },
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",

--- a/libs/express-session-redis/package.json
+++ b/libs/express-session-redis/package.json
@@ -21,6 +21,9 @@
     "dist",
     "README.md"
   ],
+  "publishConfig": {
+    "registry": "https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/npm/registry/"
+  },
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",


### PR DESCRIPTION
## Summary

The publish run for the rename refactor (#642) was partially successful. Five libs were publishable; two had `publishConfig.registry` and published cleanly (`simple-router@2.0.0`, `cloud-native-platform@2.0.0` — both now on the Azure Artifacts `hmcts-lib` feed). The other three didn't, and npm fell through to its default `registry.npmjs.org` and hit `ENEEDAUTH`:

```
🦋  error an error occurred while publishing @hmcts-cft/express-session-redis: ENEEDAUTH This command requires you to be logged in to https://registry.npmjs.org
```

This adds `publishConfig.registry` pointing at the Azure feed to:
- `@hmcts-cft/express-govuk-starter`
- `@hmcts-cft/express-session-postgres`
- `@hmcts-cft/express-session-redis`

## Test plan

- [ ] On merge to master, the release workflow re-runs `changeset publish`.
- [ ] The two already-published packages get skipped (`npm info` returns 200).
- [ ] The three packages above publish to the feed at `0.1.0`.
- [ ] Tags + GitHub releases are created for all three (and possibly for `cloud-native-platform@2.0.0` whose tag never got pushed because the previous run exited 1 mid-flight).

## Note

We should consider hardening `cnp-githubactions-library/npm-changesets-release` to write an `@<scope>:registry=` mapping in the runtime `.npmrc` so packages without `publishConfig.registry` still route correctly. Tracked separately.