### PR TITLE
test: exercise npm-scope defence on express-session-redis

### DIFF
--- a/.changeset/test-npm-scope-defense.md
+++ b/.changeset/test-npm-scope-defense.md
@@ -1,0 +1,5 @@
+---
+"@hmcts-cft/express-session-redis": patch
+---
+
+Drop `publishConfig.registry` from this lib's `package.json` to test the new `npm-scope` defence in `cnp-githubactions-library/npm-changesets-release`. The action now writes `@hmcts-cft:registry=<feed>` to the runtime `.npmrc`, so scoped publishes route to the Azure feed regardless of whether each `package.json` has `publishConfig.registry` set. If this publish succeeds, the defence works.

--- a/.github/workflows/workflow.release.yml
+++ b/.github/workflows/workflow.release.yml
@@ -16,4 +16,5 @@ jobs:
       node-version-file: '.nvmrc'
       version-command: 'yarn version-packages'
       publish-command: 'yarn release'
+      npm-scope: '@hmcts-cft'
     secrets: inherit

--- a/libs/express-session-redis/package.json
+++ b/libs/express-session-redis/package.json
@@ -21,9 +21,6 @@
     "dist",
     "README.md"
   ],
-  "publishConfig": {
-    "registry": "https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/npm/registry/"
-  },
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",


### PR DESCRIPTION
## Summary

Pass `npm-scope: '@hmcts-cft'` to the release workflow (from hmcts/cnp-githubactions-library#16) and drop `publishConfig.registry` from `express-session-redis/package.json`. The composite action now writes `@hmcts-cft:registry=<feed>` into the runtime `.npmrc`, so scoped publishes should route to Azure Artifacts even without per-package `publishConfig.registry`.

Adds a patch changeset for `@hmcts-cft/express-session-redis` to trigger a publish on merge.

## Why

Defence in depth so we never repeat the [#642 failure mode](https://github.com/hmcts/expressjs-monorepo-template/pull/642) where three libs without `publishConfig.registry` 401'd against `registry.npmjs.org`.

## Test plan
- [ ] On merge to master, a Version Packages PR opens bumping `@hmcts-cft/express-session-redis` to `0.1.1`.
- [ ] On merge of that PR, the publish succeeds despite the lib having no `publishConfig.registry`.
- [ ] `@hmcts-cft/express-session-redis@0.1.1` lands on the Azure Artifacts feed.