### PR TITLE
fix(express-govuk-starter): resolve govuk-frontend path dynamically

### DIFF
--- a/libs/express-govuk-starter/src/govuk-frontend/configure-govuk.ts
+++ b/libs/express-govuk-starter/src/govuk-frontend/configure-govuk.ts
@@ -14,7 +14,7 @@ const __dirname = path.dirname(__filename);
 
 export async function configureGovuk(app: Express, paths: string[], options: GovukSetupOptions): Promise<nunjucks.Environment> {
   const { mergedViewPaths, mergedI18nPaths } = mergeConfigs(paths);
-  const govukFrontendPath = "../../node_modules/govuk-frontend/dist";
+  const govukFrontendPath = path.join(fileURLToPath(import.meta.resolve("govuk-frontend")), "..", "..");
   const govukSetupViews = path.join(__dirname, "./views");
   const cookieViews = path.join(__dirname, "../cookies/views");
   const allViewPaths = [govukFrontendPath, govukSetupViews, cookieViews, ...mergedViewPaths];


### PR DESCRIPTION
## Summary

- Replaces hardcoded `../../node_modules/govuk-frontend/dist` with `import.meta.resolve("govuk-frontend")` so the Nunjucks template path resolves correctly when the lib is installed as a published package (not just a workspace link).

## Context

When `@hmcts-cft/express-govuk-starter` is consumed from the Azure DevOps registry (e.g. in cms-template), the relative path doesn't reach `govuk-frontend` and Nunjucks fails with `template not found: govuk/template.njk`.

## Test plan

- [ ] `yarn build` passes in expressjs-monorepo-template (workspace link still works)
- [ ] Published package resolves govuk-frontend templates when installed in a standalone project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated how the application locates and configures frontend assets, making the setup process more robust and resilient to package installation variations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmcts/expressjs-monorepo-template/pull/647)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->