### PR TITLE
chore: pin release workflow to cnp-githubactions-library@main

### DIFF
--- a/.github/workflows/workflow.release.yml
+++ b/.github/workflows/workflow.release.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   release:
-    uses: hmcts/cnp-githubactions-library/.github/workflows/npm-publish-library.yaml@feat/release-please
+    uses: hmcts/cnp-githubactions-library/.github/workflows/npm-publish-library.yaml@main
     with:
       node-version-file: '.nvmrc'
       build-command: 'yarn test && yarn build'


### PR DESCRIPTION
Now that hmcts/cnp-githubactions-library#18 has merged, move the release workflow back to a stable `@main` pin.