### PR TITLE
test: scratch workflow to probe @hmcts publish rights on npmjs

### DIFF
--- a/.github/workflows/test-npmjs-hmcts-auth.yml
+++ b/.github/workflows/test-npmjs-hmcts-auth.yml
@@ -1,0 +1,45 @@
+name: Test npmjs @hmcts publish
+
+# One-off diagnostic. Verifies whether the org-level NPM_API_TOKEN secret has
+# rights to publish a NEW package under the public @hmcts scope on npmjs.org.
+# cookie-manager publishes to @hmcts/cookie-manager (an existing package), so
+# we already know the token has update rights — what we don't know is whether
+# it can CREATE new packages under @hmcts (the suspected cause of the original
+# E404 on simple-router's first publish).
+#
+# Delete this workflow once the test is done. The published package, if any,
+# should be unpublished within 72h with: npm unpublish @hmcts/<name>
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          registry-url: https://registry.npmjs.org/
+
+      - run: corepack enable
+
+      - run: yarn install --immutable
+
+      - run: yarn workspace @hmcts-cft/simple-router run build
+
+      - name: Rename to @hmcts/<scope> and strip Azure publishConfig
+        working-directory: libs/simple-router
+        run: |
+          jq '.name = "@hmcts/expressjs-monorepo-template-publish-trial" | del(.publishConfig)' \
+             package.json > package.json.tmp && mv package.json.tmp package.json
+          echo "--- package.json after rename ---"
+          jq '{name, version, publishConfig}' package.json
+
+      - name: Try publishing under @hmcts on npmjs
+        working-directory: libs/simple-router
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_API_TOKEN }}
+        run: npm publish --access public


### PR DESCRIPTION
One-off diagnostic that publishes a renamed simple-router as `@hmcts/expressjs-monorepo-template-publish-trial` using NPM_API_TOKEN. Will be deleted after the test.