### PR TITLE
fix(express-govuk-starter): correct govuk-frontend asset path resolution

### DIFF
--- a/libs/express-govuk-starter/src/assets/configure-assets.test.ts
+++ b/libs/express-govuk-starter/src/assets/configure-assets.test.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import type { Express } from "express";
 import express from "express";
 import type nunjucks from "nunjucks";
@@ -66,6 +67,21 @@ describe("configureAssets", () => {
       const staticCalls = useSpy.mock.calls.filter((call) => typeof call[0] === "string" && call[0].startsWith("/assets/"));
       expect(staticCalls.some((call) => call[0] === "/assets/fonts")).toBe(true);
       expect(staticCalls.some((call) => call[0] === "/assets/images")).toBe(true);
+    });
+
+    it("should resolve govuk-frontend asset paths that exist on disk", async () => {
+      const staticSpy = vi.spyOn(express, "static");
+
+      await configureAssets(app, env, {
+        entries: { index_js: "/src/assets/js/index.ts" },
+        viteConfigFile: "/path/to/vite.config.ts"
+      });
+
+      const fontPath = staticSpy.mock.calls.find((call) => typeof call[0] === "string" && call[0].endsWith("/fonts"))?.[0] as string;
+      const imagePath = staticSpy.mock.calls.find((call) => typeof call[0] === "string" && call[0].endsWith("/images"))?.[0] as string;
+
+      expect(existsSync(fontPath)).toBe(true);
+      expect(existsSync(imagePath)).toBe(true);
     });
   });
 

--- a/libs/express-govuk-starter/src/assets/configure-assets.ts
+++ b/libs/express-govuk-starter/src/assets/configure-assets.ts
@@ -16,7 +16,8 @@ export async function configureAssets(app: Express, env: nunjucks.Environment, c
     });
     app.use(vite.middlewares);
 
-    const govukAssets = path.join(fileURLToPath(import.meta.resolve("govuk-frontend")), "../../dist/govuk/assets");
+    const govukFrontendPath = path.join(fileURLToPath(import.meta.resolve("govuk-frontend")), "..", "..");
+    const govukAssets = path.join(govukFrontendPath, "govuk/assets");
     app.use("/assets/fonts", express.static(path.join(govukAssets, "fonts")));
     app.use("/assets/images", express.static(path.join(govukAssets, "images")));
 


### PR DESCRIPTION
## Summary

In dev mode, requests for `/assets/fonts/*` and `/assets/images/*` return 500 because the resolved filesystem path is wrong:

```ts
const govukAssets = path.join(fileURLToPath(import.meta.resolve("govuk-frontend")), "../../dist/govuk/assets");
```

`import.meta.resolve("govuk-frontend")` returns the entry module file (e.g. `.../node_modules/govuk-frontend/dist/govuk/all.mjs`), not the package dir. Two `..` segments walk up to `.../dist/`, then re-appending `dist/govuk/assets` produces `.../dist/dist/govuk/assets` — doubled `dist`, no such directory.

This PR mirrors the pattern already used in `configure-govuk.ts` (`path.join(..., "..", "..")` to reach the package `dist/` directory) and appends `govuk/assets` from there.

## Why the existing tests missed it

The existing tests only verified that *something* was mounted at `/assets/fonts` and `/assets/images` — they never checked the resolved filesystem path was valid. Adds a regression test that `existsSync(fontPath)` and `existsSync(imagePath)` both return true.

## Test plan
- [x] `yarn test` passes (123/123) in `libs/express-govuk-starter`
- [x] Reverting the source change makes the new test fail
- [x] `yarn lint` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved asset resolution in development mode by dynamically locating the govuk-frontend package resources, replacing previous hard-coded path references.

* **Tests**
  * Added validation tests to verify asset paths are correctly resolved and accessible during development.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmcts/expressjs-monorepo-template/pull/664?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->