### PR TITLE
fix(express-govuk-starter): resolve views from dist for npm-installed consumers

### DIFF
--- a/libs/express-govuk-starter/src/govuk-frontend/configure-govuk.test.ts
+++ b/libs/express-govuk-starter/src/govuk-frontend/configure-govuk.test.ts
@@ -255,6 +255,19 @@ describe("configureGovuk", () => {
     expect(env.loaders).toBeDefined();
   });
 
+  it("should resolve the lib's own view templates", async () => {
+    const pagesPath = join(testDir, "pages");
+    mkdirSync(pagesPath, { recursive: true });
+
+    const env = await configureGovuk(app, [testDir], {
+      assetOptions: { distPath: testDir }
+    });
+
+    // default.njk ships with the lib; it must be loadable regardless of
+    // whether the consumer installed via npm (dist/) or uses workspace-link (src/).
+    expect(() => env.getTemplate("layouts/default.njk")).not.toThrow();
+  });
+
   it("should add custom nunjucks globals", async () => {
     const pagesPath = join(testDir, "pages");
     mkdirSync(pagesPath, { recursive: true });

--- a/libs/express-govuk-starter/src/govuk-frontend/configure-govuk.ts
+++ b/libs/express-govuk-starter/src/govuk-frontend/configure-govuk.ts
@@ -15,9 +15,12 @@ const __dirname = path.dirname(__filename);
 export async function configureGovuk(app: Express, paths: string[], options: GovukSetupOptions): Promise<nunjucks.Environment> {
   const { mergedViewPaths, mergedI18nPaths } = mergeConfigs(paths);
   const govukFrontendPath = path.join(fileURLToPath(import.meta.resolve("govuk-frontend")), "..", "..");
-  const srcDir = process.env.NODE_ENV !== "production" ? __dirname.replace("/dist/", "/src/") : __dirname;
-  const govukSetupViews = path.join(srcDir, "./views");
-  const cookieViews = path.join(srcDir, "../cookies/views");
+  // Views ship under dist/ for npm-installed consumers. The template's own dev
+  // mode runs tsc --watch without copying .njk files, so dist/views may be
+  // missing — fall back to src/ in that case.
+  const viewsBaseDir = existsSync(path.join(__dirname, "./views")) ? __dirname : __dirname.replace("/dist/", "/src/");
+  const govukSetupViews = path.join(viewsBaseDir, "./views");
+  const cookieViews = path.join(viewsBaseDir, "../cookies/views");
   const allViewPaths = [govukFrontendPath, govukSetupViews, cookieViews, ...mergedViewPaths];
 
   const env = nunjucks.configure(allViewPaths, {


### PR DESCRIPTION
## Summary

`configureGovuk` was unconditionally rewriting `__dirname`'s `/dist/` to `/src/` whenever `NODE_ENV !== "production"`. This only works when the lib is consumed via workspace link (the template's own dev). For consumers that install via npm (e.g. cms-template using v0.1.4), only `dist/` ships — so the rewrite points at `node_modules/@hmcts-cft/express-govuk-starter/src/govuk-frontend/views/` which doesn't exist:

```
Error: template not found: layouts/default.njk
```

This is a regression from #661 (Vite dev middleware work), introduced specifically to support the template repo's own dev workflow where `tsc --watch` doesn't copy `.njk` files into `dist/`.

## Fix

Prefer `dist/` if its views exist on disk, fall back to `src/` only when they don't:

```ts
const viewsBaseDir = existsSync(path.join(__dirname, "./views"))
  ? __dirname
  : __dirname.replace("/dist/", "/src/");
```

This preserves the workspace-link dev workflow (where dist views may be stale/missing during `tsc --watch`) while fixing npm-installed consumers regardless of `NODE_ENV`.

## Test

Adds a regression test that asserts `layouts/default.njk` is loadable after `configureGovuk`. The existing tests only checked that the nunjucks env was *defined* — they never tried to resolve a template the lib itself ships, which is why this bug slipped through.

(The test alone wouldn't catch this exact bug when run from `src/` — `__dirname` already points at `src/...` in that context. But it guards against any future breakage of the views-path logic and gives next-of-kin tests something to attach to.)

## Test plan
- [x] `yarn test` passes (124/124) in `libs/express-govuk-starter`
- [x] `yarn lint` passes
- [x] Verified locally: cms-template using the patched dist now renders `/` correctly (previously 500'd with template-not-found)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for bundled template loading across different deployment scenarios.

* **Refactor**
  * Enhanced template directory resolution to support multiple setup configurations with automatic fallback handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hmcts/expressjs-monorepo-template/pull/668?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->