### PR TITLE
feat(express-govuk-starter): support function locale entries for interpolation

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -198,6 +198,25 @@ export const POST = async (req: Request, res: Response) => {
 - **Test with `?lng=cy`** - verify all text translates correctly
 - **No hardcoded English** - all visible text must come from content objects
 
+### Interpolating dynamic values
+
+When content needs to reference runtime values, make the `en`/`cy` entry a function. It receives the rest of the view model as its context, so you interpolate with plain template literals — no separate templating layer, and the values stay type-checked:
+
+```typescript
+const en = (m: { firstName: string }) => ({
+  title: `Check your answers, ${m.firstName}`
+});
+const cy = (m: { firstName: string }) => ({
+  title: `Gwiriwch eich atebion, ${m.firstName}`
+});
+
+export const GET = async (req: Request, res: Response) => {
+  res.render("page-name", { en, cy, firstName: applicant.firstName });
+};
+```
+
+Object and function entries can be mixed; keep static pages as plain objects. Zod error messages follow the same pattern — pass the resolved (interpolated) messages into a schema factory per request, e.g. `schema((res.locals.locale === "cy" ? cy : en)({ maxLen: 100 }).errors)`. Do **not** register a global `z.setErrorMap` for localisation — it mutates process-wide state and cannot be scoped per request.
+
 ## Form Handling
 
 ### Error Display Pattern

--- a/libs/express-govuk-starter/README.md
+++ b/libs/express-govuk-starter/README.md
@@ -111,6 +111,21 @@ Express error and 404 handlers that render GOV.UK-styled error pages.
 
 i18n middleware for bilingual (English/Welsh) support. Reads `?lng=` query param and provides `t()` helper in templates.
 
+Page content is passed to `res.render` as `en` and `cy` entries; the render interceptor picks the entry matching the active locale and merges it into the view model. Each entry can be either a plain object or a **function** for interpolation. A function receives the rest of the view model (locals plus the other render data) as its context, so content strings can reference dynamic values with plain template literals:
+
+```typescript
+const en = (m: { firstName: string }) => ({
+  greeting: `Hello ${m.firstName}`
+});
+const cy = (m: { firstName: string }) => ({
+  greeting: `Helo ${m.firstName}`
+});
+
+res.render("page", { en, cy, firstName: applicant.firstName });
+```
+
+Object and function entries can be mixed, and static pages keep passing plain objects unchanged.
+
 ### `getTranslation(translations, key, locale)` / `loadTranslations(paths)`
 
 Utilities for loading and retrieving translations from `locales/en.ts` and `locales/cy.ts` files.

--- a/libs/express-govuk-starter/src/i18n/locale-middleware.test.ts
+++ b/libs/express-govuk-starter/src/i18n/locale-middleware.test.ts
@@ -443,6 +443,97 @@ describe("renderInterceptorMiddleware", () => {
     expect(next).toHaveBeenCalled();
   });
 
+  it("should call function content with the view model as interpolation context", () => {
+    const middleware = renderInterceptorMiddleware();
+    const originalRender = vi.fn();
+    const req = {} as Request;
+    const res = {
+      locals: { locale: "en", serviceName: "Test Service" },
+      render: originalRender
+    } as unknown as Response;
+    const next = vi.fn();
+
+    middleware(req, res, next);
+
+    res.render("test-view", {
+      en: (model: { firstName: string }) => ({ greeting: `Hello ${model.firstName}` }),
+      cy: (model: { firstName: string }) => ({ greeting: `Helo ${model.firstName}` }),
+      firstName: "Ada"
+    });
+
+    expect(originalRender).toHaveBeenCalledWith(
+      "test-view",
+      {
+        locale: "en",
+        serviceName: "Test Service",
+        greeting: "Hello Ada",
+        firstName: "Ada"
+      },
+      undefined
+    );
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("should call the Welsh function when locale is cy", () => {
+    const middleware = renderInterceptorMiddleware();
+    const originalRender = vi.fn();
+    const req = {} as Request;
+    const res = {
+      locals: { locale: "cy" },
+      render: originalRender
+    } as unknown as Response;
+    const next = vi.fn();
+
+    middleware(req, res, next);
+
+    res.render("test-view", {
+      en: (model: { count: number }) => ({ message: `${model.count} items` }),
+      cy: (model: { count: number }) => ({ message: `${model.count} eitem` }),
+      count: 3
+    });
+
+    expect(originalRender).toHaveBeenCalledWith(
+      "test-view",
+      {
+        locale: "cy",
+        message: "3 eitem",
+        count: 3
+      },
+      undefined
+    );
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("should support mixing a function locale with a plain-object locale", () => {
+    const middleware = renderInterceptorMiddleware();
+    const originalRender = vi.fn();
+    const req = {} as Request;
+    const res = {
+      locals: { locale: "en" },
+      render: originalRender
+    } as unknown as Response;
+    const next = vi.fn();
+
+    middleware(req, res, next);
+
+    res.render("test-view", {
+      en: (model: { name: string }) => ({ title: `Welcome ${model.name}` }),
+      cy: { title: "Croeso" },
+      name: "Sam"
+    });
+
+    expect(originalRender).toHaveBeenCalledWith(
+      "test-view",
+      {
+        locale: "en",
+        title: "Welcome Sam",
+        name: "Sam"
+      },
+      undefined
+    );
+    expect(next).toHaveBeenCalled();
+  });
+
   it("should preserve this context when calling original render", () => {
     const middleware = renderInterceptorMiddleware();
     const originalRender = vi.fn();

--- a/libs/express-govuk-starter/src/i18n/locale-middleware.ts
+++ b/libs/express-govuk-starter/src/i18n/locale-middleware.ts
@@ -82,7 +82,14 @@ export function renderInterceptorMiddleware() {
       if (opts && typeof opts === "object" && "en" in opts && "cy" in opts) {
         const { en, cy: _cy, ...otherContent } = opts;
         const locale = res.locals.locale || "en";
-        const selectedContent = opts[locale] || en || {};
+        const picked = opts[locale] || en;
+
+        // A locale entry may be a function for interpolation: it receives the
+        // rest of the view model (locals + render data) as its context, so
+        // content strings can reference dynamic values with plain template
+        // literals. Plain-object entries are used as-is.
+        const context = { ...res.locals, ...otherContent };
+        const selectedContent = (typeof picked === "function" ? picked(context) : picked) || {};
 
         // Merge selected content with existing locals
         opts = {


### PR DESCRIPTION
## What

Adds interpolation support to the `express-govuk-starter` i18n layer. An `en`/`cy` locale entry passed to `res.render` can now be a **function** as well as a plain object. When it's a function, the render interceptor calls it with the rest of the view model (locals + the other render data) as its context, so content strings can reference runtime values with plain template literals.

```typescript
const en = (m: { firstName: string }) => ({
  greeting: `Hello ${m.firstName}`
});
const cy = (m: { firstName: string }) => ({
  greeting: `Helo ${m.firstName}`
});

res.render("page", { en, cy, firstName: applicant.firstName });
```

## Why

The current model is static-only: locale entries are plain objects with no way to inject runtime values. Teams were forced to split dynamic messages into string fragments and concatenate them in templates (the `feedback.part1/part2/part3` pattern). This closes that gap without introducing a second templating layer.

Chosen over the alternative of embedding Nunjucks/`{{ }}` placeholders in translation strings because:
- it's just TypeScript — interpolated variables are **type-checked** at compile time
- no double-rendering or custom filter, no new runtime failure mode
- stays true to why this i18n approach is simple: **no runtime translation state, no shared mutation** (unlike an i18next-style singleton)

## Backwards compatibility

Fully backwards-compatible. Plain-object entries are used as-is, so every existing static page keeps working. Object and function entries can be mixed on the same render call.

## Zod error messages

The same function form covers localised Zod messages: resolve the (now interpolatable) messages per request and pass them into a schema factory — `schema((res.locals.locale === "cy" ? cy : en)({ maxLen: 100 }).errors)`. Docs explicitly steer away from a global `z.setErrorMap`, which mutates process-wide state and can't be scoped per request.

## Changes

- `locale-middleware.ts` — render interceptor calls function locale entries with the view model as context
- Tests — 3 new cases (function context, Welsh function, mixed object/function); all 127 lib tests pass
- `README.md` + `.claude/rules/frontend.md` — document the pattern and the Zod guidance

## Testing

- `npx vitest run` in `libs/express-govuk-starter` — 127 passed
- `npx tsc --noEmit` — clean
- Biome check — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Page content can now be generated from the current view data, allowing translated text to include dynamic values such as names or other request-specific details.
  * Locale-based rendering now supports both simple static content and dynamic content for each language.

* **Bug Fixes**
  * Improved locale selection so the correct language content is rendered more reliably when content is provided in different formats.

* **Documentation**
  * Expanded guidance and examples for dynamic bilingual content and request-scoped localisation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->