### PR TITLE
chore: pin Claude to Opus 5 / Sonnet 5 and drop token caps

### DIFF
--- a/.claude/run.sh
+++ b/.claude/run.sh
@@ -20,10 +20,8 @@ if [ ! -f "$ENV_FILE" ]; then
 
     # Create the env file
     cat > "$ENV_FILE" << EOF
-export CLAUDE_CODE_MAX_OUTPUT_TOKENS=4096
-export MAX_THINKING_TOKENS=1024
-export ANTHROPIC_DEFAULT_OPUS_MODEL='eu.anthropic.claude-opus-4-6-v1'
-export ANTHROPIC_DEFAULT_SONNET_MODEL='eu.anthropic.claude-sonnet-4-6'
+export ANTHROPIC_DEFAULT_OPUS_MODEL='eu.anthropic.claude-opus-5'
+export ANTHROPIC_DEFAULT_SONNET_MODEL='eu.anthropic.claude-sonnet-5'
 export ANTHROPIC_DEFAULT_HAIKU_MODEL='eu.anthropic.claude-haiku-4-5-20251001-v1:0'
 export CLAUDE_CODE_USE_BEDROCK=1
 export AWS_REGION=eu-west-1

--- a/.github/workflows/workflow.claude.yml
+++ b/.github/workflows/workflow.claude.yml
@@ -95,11 +95,9 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         env:
-          ANTHROPIC_DEFAULT_OPUS_MODEL: 'eu.anthropic.claude-opus-4-6-v1'
-          ANTHROPIC_DEFAULT_SONNET_MODEL: 'eu.anthropic.claude-sonnet-4-6'
+          ANTHROPIC_DEFAULT_OPUS_MODEL: 'eu.anthropic.claude-opus-5'
+          ANTHROPIC_DEFAULT_SONNET_MODEL: 'eu.anthropic.claude-sonnet-5'
           ANTHROPIC_DEFAULT_HAIKU_MODEL: 'eu.anthropic.claude-haiku-4-5-20251001-v1:0'
-          CLAUDE_CODE_MAX_OUTPUT_TOKENS: '4096'
-          MAX_THINKING_TOKENS: '1024'
         with:
           use_bedrock: "true"
           github_token: ${{ steps.app-token.outputs.token }}
@@ -194,11 +192,9 @@ jobs:
         if: steps.parse.outputs.valid == 'true'
         uses: anthropics/claude-code-action@v1
         env:
-          ANTHROPIC_DEFAULT_OPUS_MODEL: 'eu.anthropic.claude-opus-4-6-v1'
-          ANTHROPIC_DEFAULT_SONNET_MODEL: 'eu.anthropic.claude-sonnet-4-6'
+          ANTHROPIC_DEFAULT_OPUS_MODEL: 'eu.anthropic.claude-opus-5'
+          ANTHROPIC_DEFAULT_SONNET_MODEL: 'eu.anthropic.claude-sonnet-5'
           ANTHROPIC_DEFAULT_HAIKU_MODEL: 'eu.anthropic.claude-haiku-4-5-20251001-v1:0'
-          CLAUDE_CODE_MAX_OUTPUT_TOKENS: '4096'
-          MAX_THINKING_TOKENS: '1024'
         with:
           use_bedrock: "true"
           github_token: ${{ steps.app-token.outputs.token }}
@@ -308,11 +304,9 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         env:
-          ANTHROPIC_DEFAULT_OPUS_MODEL: 'eu.anthropic.claude-opus-4-6-v1'
-          ANTHROPIC_DEFAULT_SONNET_MODEL: 'eu.anthropic.claude-sonnet-4-6'
+          ANTHROPIC_DEFAULT_OPUS_MODEL: 'eu.anthropic.claude-opus-5'
+          ANTHROPIC_DEFAULT_SONNET_MODEL: 'eu.anthropic.claude-sonnet-5'
           ANTHROPIC_DEFAULT_HAIKU_MODEL: 'eu.anthropic.claude-haiku-4-5-20251001-v1:0'
-          CLAUDE_CODE_MAX_OUTPUT_TOKENS: '4096'
-          MAX_THINKING_TOKENS: '1024'
         with:
           use_bedrock: "true"
           github_token: ${{ steps.app-token.outputs.token }}
@@ -402,11 +396,9 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         env:
-          ANTHROPIC_DEFAULT_OPUS_MODEL: 'eu.anthropic.claude-opus-4-6-v1'
-          ANTHROPIC_DEFAULT_SONNET_MODEL: 'eu.anthropic.claude-sonnet-4-6'
+          ANTHROPIC_DEFAULT_OPUS_MODEL: 'eu.anthropic.claude-opus-5'
+          ANTHROPIC_DEFAULT_SONNET_MODEL: 'eu.anthropic.claude-sonnet-5'
           ANTHROPIC_DEFAULT_HAIKU_MODEL: 'eu.anthropic.claude-haiku-4-5-20251001-v1:0'
-          CLAUDE_CODE_MAX_OUTPUT_TOKENS: '4096'
-          MAX_THINKING_TOKENS: '1024'
         with:
           use_bedrock: "true"
           github_token: ${{ steps.app-token.outputs.token }}
@@ -502,11 +494,9 @@ jobs:
         id: claude-analysis
         uses: anthropics/claude-code-action@v1
         env:
-          ANTHROPIC_DEFAULT_OPUS_MODEL: 'eu.anthropic.claude-opus-4-6-v1'
-          ANTHROPIC_DEFAULT_SONNET_MODEL: 'eu.anthropic.claude-sonnet-4-6'
+          ANTHROPIC_DEFAULT_OPUS_MODEL: 'eu.anthropic.claude-opus-5'
+          ANTHROPIC_DEFAULT_SONNET_MODEL: 'eu.anthropic.claude-sonnet-5'
           ANTHROPIC_DEFAULT_HAIKU_MODEL: 'eu.anthropic.claude-haiku-4-5-20251001-v1:0'
-          CLAUDE_CODE_MAX_OUTPUT_TOKENS: '4096'
-          MAX_THINKING_TOKENS: '1024'
         with:
           use_bedrock: "true"
           github_token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## What

Updates the Bedrock model ids used by Claude Code in this repo, and removes the output/thinking token caps.

**Model ids** — in `.claude/run.sh` (local launcher) and all 5 `claude-code-action` jobs in `workflow.claude.yml`:

| Var | Before | After |
|---|---|---|
| `ANTHROPIC_DEFAULT_OPUS_MODEL` | `eu.anthropic.claude-opus-4-6-v1` | `eu.anthropic.claude-opus-5` |
| `ANTHROPIC_DEFAULT_SONNET_MODEL` | `eu.anthropic.claude-sonnet-4-6` | `eu.anthropic.claude-sonnet-5` |

Haiku stays on `eu.anthropic.claude-haiku-4-5-20251001-v1:0`.

**Token caps** — `CLAUDE_CODE_MAX_OUTPUT_TOKENS` (4096) and `MAX_THINKING_TOKENS` (1024) removed everywhere. Both were well below what these models support and truncated longer responses; the defaults are a better fit.

## Note for existing local setups

`.claude/run.sh` only writes `.claude/claude.env` when the file does not already exist. Anyone with an existing `claude.env` keeps their old pins — delete the file (or edit it by hand) to pick this up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default Claude Opus and Sonnet models to the latest available versions.
  * Removed legacy token-limit configuration from the Claude environment setup.
  * Applied the updated model configuration consistently across automated Claude workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->